### PR TITLE
feat: Display stream title and category in desktop notifications

### DIFF
--- a/background.js
+++ b/background.js
@@ -450,11 +450,30 @@ async function closeOfflineTabs(updatedChannels) {
 // デスクトップ通知を表示
 function showNotification(channel) {
   const notificationId = `miteruyo-live-${channel.name}-${Date.now()}`;
+
+  // Build notification message with title and category
+  let message = '';
+
+  // Add stream title if available
+  if (channel.title) {
+    message = channel.title;
+    // Add category if available
+    if (channel.game_name) {
+      message += `\n【${channel.game_name}】`;
+    }
+  } else if (channel.game_name) {
+    // Only category available
+    message = `【${channel.game_name}】`;
+  } else {
+    // Fallback to default message
+    message = chrome.i18n.getMessage('notificationTitle') || '配信開始！';
+  }
+
   const options = {
     type: 'basic',
     iconUrl: chrome.runtime.getURL('icon.png'),
-    title: chrome.i18n.getMessage('notificationTitle') || '配信開始！',
-    message: chrome.i18n.getMessage('notificationBody', [channel.name]) || `${channel.name} が配信を開始しました！`,
+    title: chrome.i18n.getMessage('notificationBody', [channel.name]) || `${channel.name} が配信を開始しました！`,
+    message: message,
     priority: 2,
     eventTime: Date.now(),
     requireInteraction: false
@@ -495,7 +514,11 @@ async function channelQueuedStreamsInMultiTwitch() {
 // メッセージリスナーを追加
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'testNotification') {
-    showNotification({ name: 'TEST_USER' });
+    showNotification({
+      name: 'TEST_USER',
+      title: 'テスト配信タイトル / Test Stream Title',
+      game_name: 'Just Chatting'
+    });
     sendResponse({ status: 'ok' });
   } else if (message.type === 'clearNotifications') {
     chrome.notifications.getAll((notifications) => {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -249,4 +249,57 @@ describe('Background Script', () => {
       expect(results[1].status).toBe('error');
     });
   });
+
+  describe('showNotification', () => {
+    // Helper to build notification message (mirrors background.js logic)
+    function buildNotificationMessage(channel) {
+      let message = '';
+
+      if (channel.title) {
+        message = channel.title;
+        if (channel.game_name) {
+          message += `\n【${channel.game_name}】`;
+        }
+      } else if (channel.game_name) {
+        message = `【${channel.game_name}】`;
+      } else {
+        message = '配信開始！';
+      }
+
+      return message;
+    }
+
+    it('should include title and category in notification message', () => {
+      const channel = {
+        name: 'testuser',
+        title: 'Playing some games!',
+        game_name: 'Just Chatting',
+      };
+
+      const message = buildNotificationMessage(channel);
+
+      expect(message).toBe('Playing some games!\n【Just Chatting】');
+    });
+
+    it('should show only title if no category', () => {
+      const channel = { name: 'testuser', title: 'My Stream' };
+      const message = buildNotificationMessage(channel);
+
+      expect(message).toBe('My Stream');
+    });
+
+    it('should show only category if no title', () => {
+      const channel = { name: 'testuser', game_name: 'Fortnite' };
+      const message = buildNotificationMessage(channel);
+
+      expect(message).toBe('【Fortnite】');
+    });
+
+    it('should fallback to default message if no title and category', () => {
+      const channel = { name: 'testuser' };
+      const message = buildNotificationMessage(channel);
+
+      expect(message).toBe('配信開始！');
+    });
+  });
 });


### PR DESCRIPTION
Show stream title and game category in notification body for better context when a channel goes live. Notification now shows channel name in title and stream details (title + category) in the message body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)