### PR TITLE
Fix #69: initialize content volume interval safely

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,5 +1,12 @@
 
+let volumeInterval = null;
 
+function stopVolumeInterval() {
+  if (volumeInterval !== null) {
+    clearInterval(volumeInterval);
+    volumeInterval = null;
+  }
+}
 
 // URLからチャンネル名を取得
 function getChannelNameFromUrl() {
@@ -24,7 +31,7 @@ async function applyVolumeSettings() {
 
   // 拡張機能のコンテキストが無効になっている場合は停止
   if (!chrome.runtime?.id) {
-    if (typeof volumeInterval !== 'undefined') clearInterval(volumeInterval);
+    stopVolumeInterval();
     return;
   }
 
@@ -44,7 +51,7 @@ async function applyVolumeSettings() {
   } catch (error) {
     if (error.message.includes('Extension context invalidated')) {
       console.log('[Miteruyo] Extension context invalidated. Stopping script.');
-      if (volumeInterval) clearInterval(volumeInterval);
+      stopVolumeInterval();
       return;
     }
     console.error('[Miteruyo] Error:', error);
@@ -93,7 +100,7 @@ urlObserver.observe(document, { subtree: true, childList: true });
 // クリーンアップ
 function cleanup() {
   urlObserver.disconnect();
-  clearInterval(volumeInterval);
+  stopVolumeInterval();
 }
 
 window.addEventListener('beforeunload', cleanup);
@@ -103,4 +110,4 @@ setTimeout(applyVolumeSettings, 1000);
 setTimeout(applyVolumeSettings, 3000);
 
 // 定期的にチェック（プレイヤーが起動時にミュートされる場合などの対策）
-const volumeInterval = setInterval(applyVolumeSettings, 5000);
+volumeInterval = setInterval(applyVolumeSettings, 5000);

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+describe('Content Script', () => {
+  async function runContentScript({ chromeOverrides = {}, path = '/testchannel' } = {}) {
+    const source = await readFile(new URL('../content.js', import.meta.url), 'utf8');
+    const asyncErrors = [];
+    const sandbox = {
+      console: {
+        log: vi.fn(),
+        error: vi.fn(),
+      },
+      window: {
+        location: { pathname: path, href: `https://www.twitch.tv${path}` },
+        addEventListener: vi.fn(),
+      },
+      location: { href: `https://www.twitch.tv${path}` },
+      document: {
+        querySelectorAll: vi.fn(() => []),
+      },
+      chrome: {
+        runtime: { id: 'extension-id' },
+        storage: {
+          local: {
+            get: vi.fn(() => Promise.resolve({ channels: [] })),
+          },
+          onChanged: {
+            addListener: vi.fn(),
+          },
+        },
+        ...chromeOverrides,
+      },
+      MutationObserver: vi.fn(function MutationObserver(callback) {
+        this.callback = callback;
+        this.observe = vi.fn();
+        this.disconnect = vi.fn();
+      }),
+      clearInterval: vi.fn(),
+      setInterval: vi.fn(() => 123),
+      setTimeout: vi.fn((callback) => {
+        const result = callback();
+        if (result?.catch) {
+          result.catch(error => asyncErrors.push(error));
+        }
+        return 1;
+      }),
+    };
+    sandbox.window.window = sandbox.window;
+    sandbox.window.document = sandbox.document;
+    sandbox.window.chrome = sandbox.chrome;
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'content.js' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    return { sandbox, asyncErrors };
+  }
+
+  it('does not touch volumeInterval before initialization when runtime is invalid', async () => {
+    const { sandbox, asyncErrors } = await runContentScript({
+      chromeOverrides: {
+        runtime: {},
+      },
+    });
+
+    expect(asyncErrors).toEqual([]);
+    expect(sandbox.clearInterval).not.toHaveBeenCalled();
+    expect(sandbox.setInterval).toHaveBeenCalledWith(expect.any(Function), 5000);
+  });
+
+  it('handles storage changes before interval assignment when runtime is invalid', async () => {
+    const addListener = vi.fn((listener) => {
+      const result = listener({ channels: {} });
+      if (result?.catch) return result.catch(() => {});
+      return undefined;
+    });
+
+    const { sandbox, asyncErrors } = await runContentScript({
+      chromeOverrides: {
+        runtime: {},
+        storage: {
+          local: {
+            get: vi.fn(() => Promise.resolve({ channels: [] })),
+          },
+          onChanged: { addListener },
+        },
+      },
+    });
+
+    expect(asyncErrors).toEqual([]);
+    expect(sandbox.clearInterval).not.toHaveBeenCalled();
+    expect(sandbox.setInterval).toHaveBeenCalledWith(expect.any(Function), 5000);
+  });
+});


### PR DESCRIPTION
## Summary
- Move content script volume interval tracking to a top-level mutable binding
- Add a shared cleanup helper that avoids TDZ access before interval assignment
- Add VM-based content script tests for early runtime invalidation paths

Fixes #69

## Verification
- npm test -- --reporter=dot tests/content.test.js
- npm test -- --reporter=dot
- npm run lint