### PR TITLE
Fix #70: guard popup category parsing

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -35,6 +35,19 @@ function migrateOAuthToken(token) {
   return token;
 }
 
+function parseCategoryOptionValue(value) {
+  try {
+    const category = JSON.parse(value);
+    if (!category || typeof category !== 'object' || typeof category.name !== 'string') {
+      return null;
+    }
+    return category;
+  } catch (error) {
+    console.error('Failed to parse category:', error);
+    return null;
+  }
+}
+
 // Category search using Twitch API
 async function searchCategories(query) {
   if (!query || query.length < 1) return [];
@@ -1038,7 +1051,9 @@ async function addChannelToList(channel, newAdded = false) {
   allowDropdown.addEventListener('change', () => {
     const selectedValue = allowDropdown.value;
     if (selectedValue) {
-      const selected = JSON.parse(selectedValue);
+      const selected = parseCategoryOptionValue(selectedValue);
+      if (!selected) return;
+
       const isAlreadyAllowed = currentAllowed.some(c =>
         (selected.id && c.id === selected.id) || c.name === selected.name
       );

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+describe('Popup Script', () => {
+  async function loadPopupTestExports() {
+    const source = await readFile(new URL('../popup.js', import.meta.url), 'utf8');
+    const helperSource = source.slice(
+      source.indexOf('function parseCategoryOptionValue'),
+      source.indexOf('// Category search using Twitch API')
+    );
+    const sandbox = {
+      console: {
+        error: vi.fn(),
+      }
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(
+      `${helperSource}\nglobalThis.__testExports = { parseCategoryOptionValue };`,
+      sandbox,
+      { filename: 'popup.js' }
+    );
+
+    return sandbox;
+  }
+
+  it('parses valid category option values', async () => {
+    const { __testExports, console } = await loadPopupTestExports();
+
+    expect(__testExports.parseCategoryOptionValue('{"id":"123","name":"Games"}')).toEqual({
+      id: '123',
+      name: 'Games',
+    });
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('ignores invalid category option values without throwing', async () => {
+    const { __testExports, console } = await loadPopupTestExports();
+
+    expect(__testExports.parseCategoryOptionValue('{bad json')).toBeNull();
+    expect(__testExports.parseCategoryOptionValue('null')).toBeNull();
+    expect(__testExports.parseCategoryOptionValue('{"id":"123"}')).toBeNull();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error.mock.calls[0][0]).toBe('Failed to parse category:');
+    expect(console.error.mock.calls[0][1].name).toBe('SyntaxError');
+  });
+});


### PR DESCRIPTION
## Summary
- Add safe parsing for popup category dropdown option values
- Ignore malformed or non-category values instead of letting `JSON.parse` crash the popup flow
- Add popup parser regression coverage for valid, malformed, null, and missing-name values

## Validation
- npm test -- --reporter=dot tests/popup.test.js
- npm test -- --reporter=dot
- npm run lint

Closes #70
