### PR TITLE
Fix #68: cache Twitch tab count during queue

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -621,6 +621,8 @@ export async function channelQueuedStreams(channelQueue) {
   const nonPriorityChannels = safeChannelQueue.filter(c => !c.isPriority);
   shuffleArray(nonPriorityChannels);
   const orderedChannels = [...priorityChannels, ...nonPriorityChannels];
+  const max = maxTabCount || 5;
+  let currentTabCount = isEnabledMaxTabs ? await countTwitchChannelTabs() : 0;
 
   if (isOpenNewWindow) {
     // ループ内で更新するためにletで宣言
@@ -628,8 +630,7 @@ export async function channelQueuedStreams(channelQueue) {
 
     for (const channel of orderedChannels) {
       if (isEnabledMaxTabs) {
-        const currentCount = await countTwitchChannelTabs();
-        if (currentCount >= (maxTabCount || 5)) break;
+        if (currentTabCount >= max) break;
       }
       if (await shouldOpenChannel(channel)) {
         console.log('channelQueueStreams', { currentWindowId });
@@ -643,6 +644,7 @@ export async function channelQueuedStreams(channelQueue) {
           if (wasOpened) {
             channel.hasBeenOpened = true;
             channelOpened = true;
+            currentTabCount++;
           }
         } else {
           // 新しいウィンドウを作成する必要がある
@@ -659,6 +661,7 @@ export async function channelQueuedStreams(channelQueue) {
             console.log('New window created, ID:', currentWindowId);
             channel.hasBeenOpened = true;
             channelOpened = true;
+            currentTabCount++;
           }
         }
       }
@@ -666,14 +669,14 @@ export async function channelQueuedStreams(channelQueue) {
   } else {
     for (const channel of orderedChannels) {
       if (isEnabledMaxTabs) {
-        const currentCount = await countTwitchChannelTabs();
-        if (currentCount >= (maxTabCount || 5)) break;
+        if (currentTabCount >= max) break;
       }
       if (await shouldOpenChannel(channel)) {
         const wasOpened = await openTabIfNotExists(channel);
         if (wasOpened) {
           channel.hasBeenOpened = true;
           channelOpened = true;
+          currentTabCount++;
         }
       }
     }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1691,6 +1691,37 @@ describe('Background Script', () => {
       expect(chromeMock.tabs.create).toHaveBeenCalledTimes(1);
     });
 
+    it('should count existing Twitch tabs once for the queue', async () => {
+      const channels = [
+        { name: 'channel1', onLive: false, onLiveOpen: true },
+        { name: 'channel2', onLive: false, onLiveOpen: true },
+        { name: 'channel3', onLive: false, onLiveOpen: true },
+      ];
+
+      chromeMock.tabs.query.mockResolvedValue([
+        { url: 'https://www.twitch.tv/existing1', id: 101 },
+      ]);
+
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (Array.isArray(keys) && keys.includes('isOpenNewWindow')) {
+          return Promise.resolve({ isOpenNewWindow: false, isEnabledMaxTabs: true, maxTabCount: 5 });
+        }
+        if (Array.isArray(keys) && keys.includes('allowedOnlyCategoryList')) {
+          return Promise.resolve({
+            allowedOnlyCategoryList: [],
+            blockedCategoryList: [],
+            blockedCategoryNames: '',
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      await channelQueuedStreams(channels);
+
+      expect(chromeMock.tabs.query).toHaveBeenCalledTimes(1);
+      expect(chromeMock.tabs.create).not.toHaveBeenCalled();
+    });
+
     it('should not limit tabs when isEnabledMaxTabs is false', async () => {
       const channels = [
         { name: 'channel1', onLive: true, onLiveOpen: true },


### PR DESCRIPTION
Summary
- Cache the existing Twitch channel tab count once before processing a queued stream batch
- Increment the cached count only when a new Twitch tab/window is opened
- Add regression coverage that max-tab counting no longer queries all tabs once per queued channel

Issues: Closes #68

Validation
- npm test -- --reporter=dot tests/background.test.js -t "should count existing Twitch tabs once for the queue"
- npm test -- --reporter=dot
- npm run lint