### PR TITLE
Fix content volume handling for non-array channels

### DIFF
--- a/content.js
+++ b/content.js
@@ -37,7 +37,7 @@ async function applyVolumeSettings() {
 
   try {
     const data = await chrome.storage.local.get(['channels']);
-    const channels = data.channels || [];
+    const channels = Array.isArray(data.channels) ? data.channels : [];
 
     // 現在のチャンネル情報を探す
     const channelInfo = channels.find(c =>

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -117,4 +117,16 @@ describe('Content Script', () => {
     expect(sandbox.console.error).not.toHaveBeenCalled();
     expect(video.volume).toBe(0.42);
   });
+
+  it('ignores non-array channel storage data when applying volume settings', async () => {
+    const video = { volume: 1 };
+    const { sandbox, asyncErrors } = await runContentScript({
+      videos: [video],
+      channels: { name: 'testchannel', enableCustomVolume: true, customVolume: '42' },
+    });
+
+    expect(asyncErrors).toEqual([]);
+    expect(sandbox.console.error).not.toHaveBeenCalled();
+    expect(video.volume).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Normalize `data.channels` to an array before content-script volume lookup
- Add a regression test for corrupted non-array channel storage data
- Keep valid custom-volume application covered by the existing malformed-entry test

Issues: Closes #77

## Validation
- `npm test -- tests/content.test.js`
- `npm test`
- `npm run lint`
