### PR TITLE
[codex] Fix background channel storage normalization

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -174,6 +174,10 @@ export function migrateOAuthToken(token) {
   return token;
 }
 
+function normalizeStoredChannels(channels) {
+  return Array.isArray(channels) ? channels : [];
+}
+
 export async function validateToken(token) {
   try {
     const response = await fetch('https://id.twitch.tv/oauth2/validate', {
@@ -193,7 +197,7 @@ export async function checkStreams() {
     console.log('checkStreams data:', {
       isEnabled: data.isEnabled,
       isEnabledNotifications: data.isEnabledNotifications,
-      channelsCount: data.channels?.length,
+      channelsCount: Array.isArray(data.channels) ? data.channels.length : 0,
       hasToken: !!data.oauth_token
     });
 
@@ -202,7 +206,7 @@ export async function checkStreams() {
       return;
     }
 
-    const channels = data.channels || [];
+    const channels = normalizeStoredChannels(data.channels);
     let oauth_token = migrateOAuthToken(data.oauth_token);
 
     if (!oauth_token || typeof oauth_token !== 'string') {
@@ -443,7 +447,7 @@ export function showNotification(channel) {
 export async function channelQueuedStreamsInMultiTwitch() {
   const data = await chrome.storage.local.get(['channels', 'isEnabled']);
   if (!data.isEnabled) return;
-  const channels = data.channels || [];
+  const channels = normalizeStoredChannels(data.channels);
   const liveChannels = channels.filter(c => c && c.onLive && c.onLiveOpen);
   if (liveChannels.length === 0) return;
 
@@ -816,6 +820,7 @@ function shuffleArray(arr) {
 }
 
 function channelURL(channel) {
+  if (channel.url) return channel.url;
   return twitchDomain + '/' + channel.name;
 }
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -13,6 +13,7 @@ import {
   validateToken,
   migrateOAuthToken,
   channelQueuedStreams,
+  channelQueuedStreamsInMultiTwitch,
   onNotificationClicked,
   openInManagedWindow,
   checkOfflineWithTab,
@@ -272,6 +273,72 @@ describe('Background Script', () => {
         expect.anything()
       );
       consoleErrorSpy.mockRestore();
+    });
+
+    it('should treat non-array stored channels as empty in checkStreams', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      globalThis.fetch = vi.fn();
+
+      chromeMock.storage.local.get.mockResolvedValue({
+        isEnabled: true,
+        isEnabledNotifications: false,
+        isOpenMultiTwitch: false,
+        channels: { testchannel: { name: 'testchannel' } },
+        oauth_token: 'test_token',
+      });
+
+      await checkStreams();
+
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(chromeMock.storage.local.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({ channels: expect.anything() })
+      );
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+        'checkStreams error:',
+        expect.anything()
+      );
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('channelQueuedStreamsInMultiTwitch', () => {
+    it('should treat non-array stored channels as empty', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        isEnabled: true,
+        channels: 'broken-channel-data',
+      });
+
+      await channelQueuedStreamsInMultiTwitch();
+
+      expect(chromeMock.tabs.query).not.toHaveBeenCalled();
+      expect(chromeMock.tabs.create).not.toHaveBeenCalled();
+    });
+
+    it('should preserve MultiTwitch URL creation for valid channel arrays', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (Array.isArray(keys) && keys.includes('channels')) {
+          return Promise.resolve({
+            isEnabled: true,
+            channels: [
+              { name: 'first', onLive: true, onLiveOpen: true },
+              { name: 'offline', onLive: false, onLiveOpen: true },
+              { name: 'second', onLive: true, onLiveOpen: true },
+            ],
+          });
+        }
+        if (keys === 'lastOpenWindowId') {
+          return Promise.resolve({ lastOpenWindowId: 10 });
+        }
+        return Promise.resolve({});
+      });
+      chromeMock.tabs.query.mockResolvedValue([]);
+
+      await channelQueuedStreamsInMultiTwitch();
+
+      expect(chromeMock.tabs.create).toHaveBeenCalledWith({
+        url: 'https://multitwitch.tv/first/second',
+        windowId: 10,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Normalize stored background `channels` before `checkStreams()` maps over them or MultiTwitch filters them.
- Preserve valid MultiTwitch URL opening by allowing the shared tab-opening helper to receive an explicit URL.
- Add background regression coverage for malformed channel storage and valid MultiTwitch URL generation.

## Root Cause
`background-functions.js` used `data.channels || []`, so truthy non-array storage values reached `.map()` / `.filter()` and crashed background processing.

Closes #79

## Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check
