### PR TITLE
Fix context menu add with malformed channels

### DIFF
--- a/background.js
+++ b/background.js
@@ -95,7 +95,7 @@ chrome.contextMenus.onClicked.addListener(async (info) => {
       };
 
       const data = await chrome.storage.local.get('channels');
-      const channels = data.channels || [];
+      const channels = Array.isArray(data.channels) ? data.channels : [];
       const index = channels.findIndex((c) => c?.name === channel.name);
 
       if (index === -1) {

--- a/tests/background-script.test.js
+++ b/tests/background-script.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createChromeMock } from './setup.js';
+
+const backgroundFunctionsMock = vi.hoisted(() => ({
+  ensureAlarmsExist: vi.fn().mockResolvedValue(undefined),
+  checkStreams: vi.fn().mockResolvedValue(undefined),
+  checkTabRotate: vi.fn().mockResolvedValue(undefined),
+  isTwitchChannelPage: vi.fn((url) => {
+    try {
+      return new URL(url).hostname.endsWith('twitch.tv');
+    } catch {
+      return false;
+    }
+  }),
+  openInManagedWindow: vi.fn().mockResolvedValue(undefined),
+  showNotification: vi.fn(),
+  checkOfflineWithTab: vi.fn().mockResolvedValue(false),
+  onWindowRemoved: vi.fn().mockResolvedValue(undefined),
+  onStorageChangedForTabRotation: vi.fn().mockResolvedValue(undefined),
+  onStorageChangedForCheckInterval: vi.fn().mockResolvedValue(undefined),
+  onNotificationClicked: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../background-functions.js', () => backgroundFunctionsMock);
+
+describe('background.js context menu channel add', () => {
+  let chromeMock;
+  let originalChrome;
+
+  async function loadContextMenuHandler() {
+    vi.resetModules();
+    await import('../background.js');
+    return chromeMock.contextMenus.onClicked.addListener.mock.calls[0][0];
+  }
+
+  beforeEach(() => {
+    chromeMock = createChromeMock();
+    originalChrome = globalThis.chrome;
+    globalThis.chrome = chromeMock;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.chrome = originalChrome;
+  });
+
+  it('adds a channel from context menu when stored channels is not an array', async () => {
+    chromeMock.storage.local.get.mockResolvedValue({ channels: { corrupted: true } });
+    const handler = await loadContextMenuHandler();
+
+    await handler({
+      menuItemId: 'addToMiteruyo',
+      linkUrl: 'https://www.twitch.tv/NewChannel',
+    });
+
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+      channels: [{
+        name: 'NewChannel',
+        categoriesFilter: '',
+        tagsFilter: '',
+        onLiveOpen: true,
+      }],
+    });
+    expect(backgroundFunctionsMock.checkStreams).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps null filtering when appending a new context menu channel', async () => {
+    chromeMock.storage.local.get.mockResolvedValue({
+      channels: [
+        null,
+        { name: 'existing', categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+      ],
+    });
+    const handler = await loadContextMenuHandler();
+
+    await handler({
+      menuItemId: 'addToMiteruyo',
+      pageUrl: 'https://www.twitch.tv/another',
+    });
+
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+      channels: [
+        { name: 'existing', categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+        { name: 'another', categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize `data.channels` in the background context-menu add path before array operations
- Add service-worker import coverage for adding channels when stored `channels` is malformed
- Keep existing null-entry filtering behavior when appending a valid channel

Closes #83

## Validation
- `npm test -- tests/background-script.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`
