### PR TITLE
Fix category filter normalization

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -178,6 +178,14 @@ function normalizeStoredChannels(channels) {
   return Array.isArray(channels) ? channels : [];
 }
 
+function normalizeCategoryList(categories) {
+  if (!Array.isArray(categories)) return [];
+
+  return categories.map(item =>
+    typeof item === 'string' ? { id: null, name: item } : (item || { id: null, name: '' })
+  ).filter(item => item.name);
+}
+
 export async function validateToken(token) {
   try {
     const response = await fetch('https://id.twitch.tv/oauth2/validate', {
@@ -512,14 +520,10 @@ export async function shouldOpenChannel(channel, { forAutoClose = false } = {}) 
   // Priority: allowedOnlyCategoryList > blocked/allowed lists
 
   // Check for allowed-only categories (individual then global)
-  const channelAllowedOnlyList = (channel.allowedOnlyCategoryList || []).map(item =>
-    typeof item === 'string' ? { id: null, name: item } : (item || { id: null, name: '' })
-  ).filter(item => item.name);
+  const channelAllowedOnlyList = normalizeCategoryList(channel.allowedOnlyCategoryList);
 
   const storageData = await chrome.storage.local.get(['allowedOnlyCategoryList', 'blockedCategoryList', 'blockedCategoryNames']);
-  const globalAllowedOnlyList = (storageData.allowedOnlyCategoryList || []).map(item =>
-    typeof item === 'string' ? { id: null, name: item } : (item || { id: null, name: '' })
-  ).filter(item => item.name);
+  const globalAllowedOnlyList = normalizeCategoryList(storageData.allowedOnlyCategoryList);
 
   // If allowed-only list is set (individual or global), ONLY open if category matches
   if (channelAllowedOnlyList.length > 0 || globalAllowedOnlyList.length > 0) {
@@ -549,7 +553,7 @@ export async function shouldOpenChannel(channel, { forAutoClose = false } = {}) 
   }
 
   // Original blocked/allowed logic (when no allowed-only list is set)
-  let globalBlockedList = storageData.blockedCategoryList || [];
+  let globalBlockedList = normalizeCategoryList(storageData.blockedCategoryList);
 
   // Migrate from old comma-separated format if needed
   if (globalBlockedList.length === 0 && storageData.blockedCategoryNames) {
@@ -561,18 +565,9 @@ export async function shouldOpenChannel(channel, { forAutoClose = false } = {}) 
       .map(name => ({ id: null, name }));
   }
 
-  // Normalize to {id, name} format if old string array
-  globalBlockedList = globalBlockedList.map(item =>
-    typeof item === 'string' ? { id: null, name: item } : (item || { id: null, name: '' })
-  ).filter(item => item.name);
+  const channelBlockedList = normalizeCategoryList(channel.blockedCategoryList);
 
-  const channelBlockedList = (channel.blockedCategoryList || []).map(item =>
-    typeof item === 'string' ? { id: null, name: item } : (item || { id: null, name: '' })
-  ).filter(item => item.name);
-
-  const allowedCategoryList = (channel.allowedCategoryList || channel.allowedCategories || []).map(item =>
-    typeof item === 'string' ? { id: null, name: item } : (item || { id: null, name: '' })
-  ).filter(item => item.name);
+  const allowedCategoryList = normalizeCategoryList(channel.allowedCategoryList || channel.allowedCategories);
 
   // Combine both global and channel-specific blocked categories
   const combinedBlockedList = [...globalBlockedList, ...channelBlockedList];

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -845,6 +845,54 @@ describe('Background Script', () => {
       });
       expect(result).toBe(true);
     });
+
+    it('should ignore non-array category filters without throwing', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string' && keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        return Promise.resolve({
+          allowedOnlyCategoryList: { id: '123', name: 'Broken Allowed Only' },
+          blockedCategoryList: 'Broken Blocked',
+          blockedCategoryNames: '',
+        });
+      });
+
+      const result = await shouldOpenChannel({
+        name: 'test',
+        onLive: true,
+        onLiveOpen: true,
+        game_id: '456',
+        game_name: 'Test Game',
+        allowedOnlyCategoryList: 'Broken Channel Allowed Only',
+        blockedCategoryList: { id: '456', name: 'Broken Channel Blocked' },
+        allowedCategoryList: { id: '456', name: 'Broken Channel Allowed' },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should preserve string category filter entries', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string' && keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        return Promise.resolve({
+          allowedOnlyCategoryList: [],
+          blockedCategoryList: ['Blocked Game'],
+          blockedCategoryNames: '',
+        });
+      });
+
+      const result = await shouldOpenChannel({
+        name: 'test',
+        onLive: true,
+        onLiveOpen: true,
+        game_name: 'Blocked Game',
+      });
+
+      expect(result).toBe(false);
+    });
   });
 
   describe('tabRotationAlarm', () => {


### PR DESCRIPTION
## Summary
- Normalize category filter storage fields before `shouldOpenChannel()` maps them
- Treat non-array global and per-channel category filters as empty lists
- Add regressions for broken category filter values and existing string-array filters

Issues: Closes #85

## Validation
- `npm test -- tests/background.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`
