### PR TITLE
Fix blocked category migration for null IDs

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -359,7 +359,7 @@ async function migrateBlockedCategories() {
   // Check if already in new format (array of objects with id)
   if (data.blockedCategoryList && Array.isArray(data.blockedCategoryList)) {
     // Check if it's already in {id, name} format
-    if (data.blockedCategoryList.length === 0 || (data.blockedCategoryList[0] && typeof data.blockedCategoryList[0] === 'object' && data.blockedCategoryList[0].id)) {
+    if (data.blockedCategoryList.length === 0 || (data.blockedCategoryList[0] && typeof data.blockedCategoryList[0] === 'object' && 'id' in data.blockedCategoryList[0] && 'name' in data.blockedCategoryList[0])) {
       return data.blockedCategoryList;
     }
     // Migrate from string array to object array (id will be name for backwards compatibility)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -9,6 +9,10 @@ describe('Popup Script', () => {
       source.indexOf('function normalizeStoredChannels'),
       source.indexOf('// Category search using Twitch API')
     );
+    const migrationSource = source.slice(
+      source.indexOf('async function migrateBlockedCategories'),
+      source.indexOf('// Migrate allowed-only categories')
+    );
     const sandbox = {
       console: {
         error: vi.fn(),
@@ -17,7 +21,7 @@ describe('Popup Script', () => {
 
     vm.createContext(sandbox);
     vm.runInContext(
-      `${helperSource}\nglobalThis.__testExports = { normalizeStoredChannels, parseCategoryOptionValue };`,
+      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, migrateBlockedCategories, parseCategoryOptionValue };`,
       sandbox,
       { filename: 'popup.js' }
     );
@@ -54,5 +58,25 @@ describe('Popup Script', () => {
     expect(__testExports.normalizeStoredChannels(null)).toEqual([]);
     expect(__testExports.normalizeStoredChannels('broken')).toEqual([]);
     expect(__testExports.normalizeStoredChannels({ 0: { name: 'broken' } })).toEqual([]);
+  });
+
+  it('keeps migrated blocked category objects with null ids', async () => {
+    const sandbox = await loadPopupTestExports();
+    const { __testExports } = sandbox;
+    const blockedCategoryList = [{ id: null, name: 'Just Chatting' }];
+    const set = vi.fn();
+
+    const chrome = {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({ blockedCategoryList }),
+          set,
+        },
+      },
+    };
+    sandbox.chrome = chrome;
+
+    await expect(__testExports.migrateBlockedCategories()).resolves.toBe(blockedCategoryList);
+    expect(set).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Treat blocked category objects with `id: null` and `name` as already migrated
- Add a popup regression test so migrated blocked category objects are not wrapped again

Closes #87

## Validation
- npm test -- tests/popup.test.js
- npm test
- npm run lint
- git diff --check
