### PR TITLE
Fix background category name normalization

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -181,9 +181,16 @@ function normalizeStoredChannels(channels) {
 function normalizeCategoryList(categories) {
   if (!Array.isArray(categories)) return [];
 
-  return categories.map(item =>
-    typeof item === 'string' ? { id: null, name: item } : (item || { id: null, name: '' })
-  ).filter(item => item.name);
+  return categories
+    .map(item =>
+      typeof item === 'string' ? { id: null, name: item } : item
+    )
+    .filter(item =>
+      item &&
+      typeof item === 'object' &&
+      typeof item.name === 'string' &&
+      item.name
+    );
 }
 
 export async function validateToken(token) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -893,6 +893,41 @@ describe('Background Script', () => {
 
       expect(result).toBe(false);
     });
+
+    it('should ignore category filter entries with non-string names without throwing', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string' && keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        return Promise.resolve({
+          allowedOnlyCategoryList: [
+            { id: '999', name: { broken: true } },
+            { id: '123', name: 'Allowed Game' },
+          ],
+          blockedCategoryList: [
+            { id: '456', name: 123 },
+            { id: '789', name: 'Other Blocked Game' },
+          ],
+          blockedCategoryNames: '',
+        });
+      });
+
+      const result = await shouldOpenChannel({
+        name: 'test',
+        onLive: true,
+        onLiveOpen: true,
+        game_id: '123',
+        game_name: 'Allowed Game',
+        allowedOnlyCategoryList: [
+          { id: '456', name: ['broken'] },
+          { id: '123', name: 'Allowed Game' },
+        ],
+        allowedCategoryList: [{ id: '456', name: { broken: true } }],
+        blockedCategoryList: [{ id: '456', name: { broken: true } }],
+      });
+
+      expect(result).toBe(true);
+    });
   });
 
   describe('tabRotationAlarm', () => {


### PR DESCRIPTION
## Summary
- ignore malformed category filter entries whose `name` is not a string in background `normalizeCategoryList()`
- keep legacy string category filters working as `{ id: null, name }`
- add a `shouldOpenChannel()` regression for mixed malformed and valid category entries

Issues: Closes #91

## Validation
- `npm test -- tests/background.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`
