### PR TITLE
[codex] Normalize popup allowed-only migration

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -404,14 +404,15 @@ async function migrateBlockedCategories() {
 async function migrateAllowedOnlyCategories() {
   const data = await chrome.storage.local.get(['allowedOnlyCategoryList']);
 
-  // Check if already in new format (array of objects with id)
-  if (data.allowedOnlyCategoryList && Array.isArray(data.allowedOnlyCategoryList)) {
-    // Check if it's already in {id, name} format
-    if (data.allowedOnlyCategoryList.length === 0 || (data.allowedOnlyCategoryList[0] && typeof data.allowedOnlyCategoryList[0] === 'object' && 'id' in data.allowedOnlyCategoryList[0])) {
+  if (Array.isArray(data.allowedOnlyCategoryList)) {
+    const migrated = normalizeCategoryList(data.allowedOnlyCategoryList);
+    const alreadyNormalized = migrated.length === data.allowedOnlyCategoryList.length &&
+      migrated.every((category, index) => category === data.allowedOnlyCategoryList[index]);
+
+    if (alreadyNormalized) {
       return data.allowedOnlyCategoryList;
     }
-    // Migrate from string array to object array (id will be null for backwards compatibility)
-    const migrated = data.allowedOnlyCategoryList.map(name => ({ id: null, name }));
+
     await chrome.storage.local.set({ allowedOnlyCategoryList: migrated });
     return migrated;
   }

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -11,7 +11,7 @@ describe('Popup Script', () => {
     );
     const migrationSource = source.slice(
       source.indexOf('async function migrateBlockedCategories'),
-      source.indexOf('// Migrate allowed-only categories')
+      source.indexOf('// Render global allowed-only categories tag list')
     );
     const sandbox = {
       console: {
@@ -21,7 +21,7 @@ describe('Popup Script', () => {
 
     vm.createContext(sandbox);
     vm.runInContext(
-      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeCategoryList, migrateBlockedCategories, parseCategoryOptionValue };`,
+      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue };`,
       sandbox,
       { filename: 'popup.js' }
     );
@@ -92,5 +92,32 @@ describe('Popup Script', () => {
 
     await expect(__testExports.migrateBlockedCategories()).resolves.toBe(blockedCategoryList);
     expect(set).not.toHaveBeenCalled();
+  });
+
+  it('normalizes malformed allowed-only category objects during migration', async () => {
+    const sandbox = await loadPopupTestExports();
+    const { __testExports } = sandbox;
+    const allowedOnlyCategoryList = [
+      { id: '1' },
+      { id: '2', name: { broken: true } },
+      { id: '3', name: 'Just Chatting' },
+    ];
+    const set = vi.fn();
+
+    sandbox.chrome = {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({ allowedOnlyCategoryList }),
+          set,
+        },
+      },
+    };
+
+    await expect(__testExports.migrateAllowedOnlyCategories()).resolves.toEqual([
+      { id: '3', name: 'Just Chatting' },
+    ]);
+    expect(set).toHaveBeenCalledWith({
+      allowedOnlyCategoryList: [{ id: '3', name: 'Just Chatting' }],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Normalize `allowedOnlyCategoryList` during popup migration with the shared category sanitizer
- Persist cleaned allowed-only category data when malformed entries are removed or legacy strings are migrated
- Add a popup regression test for malformed allowed-only entries that should not disable blocked category UI invisibly

Issues: Closes #93

## Validation
- `npm test -- tests/popup.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`
