### PR TITLE
Fix blocked category migration normalization

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -373,14 +373,15 @@ function renderCategoryTags({ container, categories, badgeClass, onDelete }) {
 async function migrateBlockedCategories() {
   const data = await chrome.storage.local.get(['blockedCategoryNames', 'blockedCategoryList']);
 
-  // Check if already in new format (array of objects with id)
-  if (data.blockedCategoryList && Array.isArray(data.blockedCategoryList)) {
-    // Check if it's already in {id, name} format
-    if (data.blockedCategoryList.length === 0 || (data.blockedCategoryList[0] && typeof data.blockedCategoryList[0] === 'object' && 'id' in data.blockedCategoryList[0] && 'name' in data.blockedCategoryList[0])) {
+  if (Array.isArray(data.blockedCategoryList)) {
+    const migrated = normalizeCategoryList(data.blockedCategoryList);
+    const alreadyNormalized = migrated.length === data.blockedCategoryList.length &&
+      migrated.every((category, index) => category === data.blockedCategoryList[index]);
+
+    if (alreadyNormalized) {
       return data.blockedCategoryList;
     }
-    // Migrate from string array to object array (id will be name for backwards compatibility)
-    const migrated = data.blockedCategoryList.map(name => ({ id: null, name }));
+
     await chrome.storage.local.set({ blockedCategoryList: migrated });
     return migrated;
   }

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -94,6 +94,33 @@ describe('Popup Script', () => {
     expect(set).not.toHaveBeenCalled();
   });
 
+  it('normalizes malformed blocked category objects during migration', async () => {
+    const sandbox = await loadPopupTestExports();
+    const { __testExports } = sandbox;
+    const blockedCategoryList = [
+      { id: '1' },
+      { id: '2', name: { broken: true } },
+      { id: '3', name: 'Just Chatting' },
+    ];
+    const set = vi.fn();
+
+    sandbox.chrome = {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({ blockedCategoryList }),
+          set,
+        },
+      },
+    };
+
+    await expect(__testExports.migrateBlockedCategories()).resolves.toEqual([
+      { id: '3', name: 'Just Chatting' },
+    ]);
+    expect(set).toHaveBeenCalledWith({
+      blockedCategoryList: [{ id: '3', name: 'Just Chatting' }],
+    });
+  });
+
   it('normalizes malformed allowed-only category objects during migration', async () => {
     const sandbox = await loadPopupTestExports();
     const { __testExports } = sandbox;


### PR DESCRIPTION
## Summary
- Normalize `blockedCategoryList` through the shared popup category normalizer during migration
- Persist cleaned blocked category data when malformed entries are removed or legacy strings are migrated
- Add a popup regression test for malformed blocked category objects blocking re-adds

Issues: Closes #95

## Validation
- `npm test -- tests/popup.test.js` (confirmed failing before the fix, passing after)
- `npm test`
- `npm run lint`
- `git diff --check`
