### PR TITLE
Fix empty category name normalization

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -52,7 +52,8 @@ function normalizeCategoryList(categories) {
     .filter(category =>
       category &&
       typeof category === 'object' &&
-      typeof category.name === 'string'
+      typeof category.name === 'string' &&
+      category.name !== ''
     );
 }
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -71,7 +71,7 @@ describe('Popup Script', () => {
     expect(__testExports.normalizeCategoryList(null)).toEqual([]);
     expect(__testExports.normalizeCategoryList('broken')).toEqual([]);
     expect(__testExports.normalizeCategoryList({ 0: { id: '1', name: 'Broken' } })).toEqual([]);
-    expect(__testExports.normalizeCategoryList([{ id: '1' }, null, 1])).toEqual([]);
+    expect(__testExports.normalizeCategoryList([{ id: '1' }, { id: '2', name: '' }, '', null, 1])).toEqual([]);
   });
 
   it('keeps migrated blocked category objects with null ids', async () => {
@@ -100,6 +100,7 @@ describe('Popup Script', () => {
     const blockedCategoryList = [
       { id: '1' },
       { id: '2', name: { broken: true } },
+      { id: '3', name: '' },
       { id: '3', name: 'Just Chatting' },
     ];
     const set = vi.fn();
@@ -127,6 +128,7 @@ describe('Popup Script', () => {
     const allowedOnlyCategoryList = [
       { id: '1' },
       { id: '2', name: { broken: true } },
+      { id: '3', name: '' },
       { id: '3', name: 'Just Chatting' },
     ];
     const set = vi.fn();


### PR DESCRIPTION
## Summary
- Drop empty-string category names from popup-side category normalization.
- Ensure blocked and allowed-only category migrations persist cleaned lists when empty names are present.
- Extend popup regression coverage for empty category names in normalization and migrations.

## Root cause
`popup.js` accepted category objects as long as `name` was a string, so `{ id: "123", name: "" }` counted as an allowed-only category in popup UI state. The background path already ignores empty names, which made the popup disable blocked-category controls even though runtime auto-open filtering had no effective allowed-only category.

Closes #97

## Validation
- `npm test -- tests/popup.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`
