### PR TITLE
[codex] Ignore whitespace-only category names

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -189,7 +189,7 @@ function normalizeCategoryList(categories) {
       item &&
       typeof item === 'object' &&
       typeof item.name === 'string' &&
-      item.name
+      item.name.trim() !== ''
     );
 }
 

--- a/popup.js
+++ b/popup.js
@@ -53,7 +53,7 @@ function normalizeCategoryList(categories) {
       category &&
       typeof category === 'object' &&
       typeof category.name === 'string' &&
-      category.name !== ''
+      category.name.trim() !== ''
     );
 }
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -928,6 +928,54 @@ describe('Background Script', () => {
 
       expect(result).toBe(true);
     });
+
+    it('should ignore whitespace-only allowed-only category names', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string' && keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        return Promise.resolve({
+          allowedOnlyCategoryList: [{ id: '999', name: '   ' }],
+          blockedCategoryList: [],
+          blockedCategoryNames: '',
+        });
+      });
+
+      const result = await shouldOpenChannel({
+        name: 'test',
+        onLive: true,
+        onLiveOpen: true,
+        game_id: '123',
+        game_name: 'Test Game',
+        allowedOnlyCategoryList: [{ id: '456', name: '   ' }],
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should ignore whitespace-only blocked category names', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string' && keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        return Promise.resolve({
+          allowedOnlyCategoryList: [],
+          blockedCategoryList: [{ id: '123', name: '   ' }],
+          blockedCategoryNames: '',
+        });
+      });
+
+      const result = await shouldOpenChannel({
+        name: 'test',
+        onLive: true,
+        onLiveOpen: true,
+        game_id: '123',
+        game_name: 'Test Game',
+        blockedCategoryList: [{ id: '123', name: '   ' }],
+      });
+
+      expect(result).toBe(true);
+    });
   });
 
   describe('tabRotationAlarm', () => {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -71,7 +71,7 @@ describe('Popup Script', () => {
     expect(__testExports.normalizeCategoryList(null)).toEqual([]);
     expect(__testExports.normalizeCategoryList('broken')).toEqual([]);
     expect(__testExports.normalizeCategoryList({ 0: { id: '1', name: 'Broken' } })).toEqual([]);
-    expect(__testExports.normalizeCategoryList([{ id: '1' }, { id: '2', name: '' }, '', null, 1])).toEqual([]);
+    expect(__testExports.normalizeCategoryList([{ id: '1' }, { id: '2', name: '' }, { id: '3', name: '   ' }, '', '  ', null, 1])).toEqual([]);
   });
 
   it('keeps migrated blocked category objects with null ids', async () => {
@@ -101,7 +101,8 @@ describe('Popup Script', () => {
       { id: '1' },
       { id: '2', name: { broken: true } },
       { id: '3', name: '' },
-      { id: '3', name: 'Just Chatting' },
+      { id: '4', name: '   ' },
+      { id: '5', name: 'Just Chatting' },
     ];
     const set = vi.fn();
 
@@ -115,10 +116,10 @@ describe('Popup Script', () => {
     };
 
     await expect(__testExports.migrateBlockedCategories()).resolves.toEqual([
-      { id: '3', name: 'Just Chatting' },
+      { id: '5', name: 'Just Chatting' },
     ]);
     expect(set).toHaveBeenCalledWith({
-      blockedCategoryList: [{ id: '3', name: 'Just Chatting' }],
+      blockedCategoryList: [{ id: '5', name: 'Just Chatting' }],
     });
   });
 
@@ -129,7 +130,8 @@ describe('Popup Script', () => {
       { id: '1' },
       { id: '2', name: { broken: true } },
       { id: '3', name: '' },
-      { id: '3', name: 'Just Chatting' },
+      { id: '4', name: '   ' },
+      { id: '5', name: 'Just Chatting' },
     ];
     const set = vi.fn();
 
@@ -143,10 +145,10 @@ describe('Popup Script', () => {
     };
 
     await expect(__testExports.migrateAllowedOnlyCategories()).resolves.toEqual([
-      { id: '3', name: 'Just Chatting' },
+      { id: '5', name: 'Just Chatting' },
     ]);
     expect(set).toHaveBeenCalledWith({
-      allowedOnlyCategoryList: [{ id: '3', name: 'Just Chatting' }],
+      allowedOnlyCategoryList: [{ id: '5', name: 'Just Chatting' }],
     });
   });
 });


### PR DESCRIPTION
## Summary

- Drop category entries whose `name` is whitespace-only in popup and background category normalization.
- Preserve valid category display names without trimming them.
- Add popup migration and background `shouldOpenChannel()` regressions for whitespace-only category names.

Issues: Closes #99

## Validation

- `npm ci`
- `npm test -- tests/popup.test.js tests/background.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`
