### PR TITLE
Avoid logging Twitch OAuth redirect URL

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1539,7 +1539,6 @@ async function refreshList() {
 
 
 loginTwitch.addEventListener('click', () => {
-  console.log(chrome.identity.getRedirectURL());
   const state = crypto.randomUUID();
   chrome.identity.launchWebAuthFlow({
     url: 'https://id.twitch.tv/oauth2/authorize?' +
@@ -1550,37 +1549,38 @@ loginTwitch.addEventListener('click', () => {
       `state=${state}`,
     interactive: true
   }, responseUrl => {
-    console.log({ responseUrl });
-    if (responseUrl) {
-      let hash = new URL(responseUrl).hash;
-      let result = parseHashToObj(hash);
-      if (result.state !== state) {
-        console.error('OAuth state mismatch: possible CSRF attack');
-        rewriteNeedsLoginButton(false);
-        return;
-      }
-      const oauth_token = result.access_token;
-      chrome.storage.local.set({ oauth_token });
-      checkTwitchConnection(oauth_token);
-    } else {
-      console.error('Invalid response URL:', responseUrl);
-      rewriteNeedsLoginButton(false);
-    }
+    handleTwitchAuthResponse(responseUrl, state);
   });
 });
+
+function handleTwitchAuthResponse(responseUrl, state) {
+  if (responseUrl) {
+    let hash = new URL(responseUrl).hash;
+    let result = parseHashToObj(hash);
+    if (result.state !== state) {
+      console.error('OAuth state mismatch: possible CSRF attack');
+      rewriteNeedsLoginButton(false);
+      return;
+    }
+    const oauth_token = result.access_token;
+    chrome.storage.local.set({ oauth_token });
+    checkTwitchConnection(oauth_token);
+  } else {
+    console.error('Invalid response URL:', responseUrl);
+    rewriteNeedsLoginButton(false);
+  }
+}
 
 function parseHashToObj(hash) {
   return Object.fromEntries(new URLSearchParams(hash.replace('#', '')));
 }
 
 function checkTwitchConnection(oauthToken) {
-  console.log('checkTwitch');
   const token = oauthToken;
   return fetch('https://id.twitch.tv/oauth2/validate', {
     headers: { 'Authorization': 'OAuth ' + token },
   })
     .then(response => {
-      console.log(response);
       rewriteNeedsLoginButton(response.ok);
       return response.ok;
     })

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -15,6 +15,7 @@ describe('Popup Script', () => {
     );
     const sandbox = {
       console: {
+        log: vi.fn(),
         error: vi.fn(),
       }
     };
@@ -22,6 +23,39 @@ describe('Popup Script', () => {
     vm.createContext(sandbox);
     vm.runInContext(
       `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory };`,
+      sandbox,
+      { filename: 'popup.js' }
+    );
+
+    return sandbox;
+  }
+
+  async function loadPopupAuthExports() {
+    const source = await readFile(new URL('../popup.js', import.meta.url), 'utf8');
+    const authSource = source.slice(
+      source.indexOf('function handleTwitchAuthResponse'),
+      source.indexOf('function checkTwitchConnection')
+    );
+    const sandbox = {
+      chrome: {
+        storage: {
+          local: {
+            set: vi.fn(),
+          },
+        },
+      },
+      checkTwitchConnection: vi.fn(),
+      console: {
+        log: vi.fn(),
+        error: vi.fn(),
+      },
+      URL,
+      URLSearchParams,
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(
+      `${authSource}\nglobalThis.__testExports = { handleTwitchAuthResponse, parseHashToObj };`,
       sandbox,
       { filename: 'popup.js' }
     );
@@ -185,5 +219,17 @@ describe('Popup Script', () => {
       { id: null, name: ' ' },
       { id: null, name: '' }
     )).toBe(false);
+  });
+
+  it('handles Twitch auth tokens without logging the redirect URL', async () => {
+    const sandbox = await loadPopupAuthExports();
+    const { __testExports, chrome, checkTwitchConnection, console } = sandbox;
+    const responseUrl = 'https://example.chromiumapp.org/#access_token=secret-token&state=state-1';
+
+    __testExports.handleTwitchAuthResponse(responseUrl, 'state-1');
+
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({ oauth_token: 'secret-token' });
+    expect(checkTwitchConnection).toHaveBeenCalledWith('secret-token');
+    expect(console.log).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #103

## Summary
- remove Twitch OAuth redirect URL and validation response console logging from popup login flow
- extract the auth redirect handler for focused test coverage
- add a popup regression test that stores the token without logging the credential-bearing redirect URL

## Validation
- npm test -- tests/popup.test.js
- npm test
- npm run lint
- git diff --check