### PR TITLE
Reject OAuth callbacks without access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Check the service worker console for:
 - `Timeout for {channel}:` - Request exceeded 10 seconds
 - `HTTP error 401:` - OAuth token expired/invalid
 
+### Twitch Login Callback Errors
+If the Twitch OAuth redirect is canceled, denied, malformed, or missing `access_token`, Miteruyo leaves any stored token unchanged and asks you to log in again from the popup.
+
 ### Storage Issues
 - Clear extension storage: `chrome.storage.local.clear()`
 - Re-authenticate via extension popup

--- a/popup.js
+++ b/popup.js
@@ -1554,25 +1554,50 @@ loginTwitch.addEventListener('click', () => {
 });
 
 function handleTwitchAuthResponse(responseUrl, state) {
-  if (responseUrl) {
-    let hash = new URL(responseUrl).hash;
-    let result = parseHashToObj(hash);
-    if (result.state !== state) {
-      console.error('OAuth state mismatch: possible CSRF attack');
-      rewriteNeedsLoginButton(false);
-      return;
-    }
-    const oauth_token = result.access_token;
-    chrome.storage.local.set({ oauth_token });
-    checkTwitchConnection(oauth_token);
-  } else {
-    console.error('Invalid response URL:', responseUrl);
+  if (!responseUrl) {
+    console.error('Invalid OAuth response');
     rewriteNeedsLoginButton(false);
+    return;
   }
+
+  let result;
+  try {
+    const callbackUrl = new URL(responseUrl);
+    const fragmentParams = parseHashToObj(callbackUrl.hash);
+    result = {
+      ...Object.fromEntries(callbackUrl.searchParams),
+      ...fragmentParams,
+      access_token: fragmentParams.access_token,
+    };
+  } catch {
+    console.error('Invalid OAuth response');
+    rewriteNeedsLoginButton(false);
+    return;
+  }
+
+  if (result.state !== state) {
+    console.error('OAuth state mismatch: possible CSRF attack');
+    rewriteNeedsLoginButton(false);
+    return;
+  }
+
+  const oauth_token = result.access_token;
+  if (!isValidOAuthAccessToken(oauth_token)) {
+    console.error('OAuth response missing access token');
+    rewriteNeedsLoginButton(false);
+    return;
+  }
+
+  chrome.storage.local.set({ oauth_token });
+  checkTwitchConnection(oauth_token);
 }
 
 function parseHashToObj(hash) {
   return Object.fromEntries(new URLSearchParams(hash.replace('#', '')));
+}
+
+function isValidOAuthAccessToken(accessToken) {
+  return typeof accessToken === 'string' && accessToken.trim() !== '';
 }
 
 function checkTwitchConnection(oauthToken) {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -45,6 +45,7 @@ describe('Popup Script', () => {
         },
       },
       checkTwitchConnection: vi.fn(),
+      rewriteNeedsLoginButton: vi.fn(),
       console: {
         log: vi.fn(),
         error: vi.fn(),
@@ -231,5 +232,51 @@ describe('Popup Script', () => {
     expect(chrome.storage.local.set).toHaveBeenCalledWith({ oauth_token: 'secret-token' });
     expect(checkTwitchConnection).toHaveBeenCalledWith('secret-token');
     expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing token', 'https://example.chromiumapp.org/#state=state-1&token_type=bearer'],
+    ['query-string error token', 'https://example.chromiumapp.org/?error=access_denied&state=state-1'],
+    ['query-string token', 'https://example.chromiumapp.org/?access_token=query-token&state=state-1'],
+    ['empty token', 'https://example.chromiumapp.org/#access_token=&state=state-1&token_type=bearer'],
+    ['blank token', 'https://example.chromiumapp.org/#access_token=%20%20&state=state-1&token_type=bearer'],
+  ])('rejects matching-state auth callbacks with %s', async (_name, responseUrl) => {
+    const sandbox = await loadPopupAuthExports();
+    const { __testExports, chrome, checkTwitchConnection, rewriteNeedsLoginButton, console } = sandbox;
+
+    __testExports.handleTwitchAuthResponse(responseUrl, 'state-1');
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(checkTwitchConnection).not.toHaveBeenCalled();
+    expect(rewriteNeedsLoginButton).toHaveBeenCalledWith(false);
+    expect(console.error).toHaveBeenCalledWith('OAuth response missing access token');
+  });
+
+  it('rejects malformed auth callbacks without logging the raw response', async () => {
+    const sandbox = await loadPopupAuthExports();
+    const { __testExports, chrome, checkTwitchConnection, rewriteNeedsLoginButton, console } = sandbox;
+
+    __testExports.handleTwitchAuthResponse('not a valid URL', 'state-1');
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(checkTwitchConnection).not.toHaveBeenCalled();
+    expect(rewriteNeedsLoginButton).toHaveBeenCalledWith(false);
+    expect(console.error).toHaveBeenCalledWith('Invalid OAuth response');
+    expect(console.error.mock.calls.flat().join('\n')).not.toContain('not a valid URL');
+  });
+
+  it('preserves state mismatch rejection before token storage', async () => {
+    const sandbox = await loadPopupAuthExports();
+    const { __testExports, chrome, checkTwitchConnection, rewriteNeedsLoginButton, console } = sandbox;
+
+    __testExports.handleTwitchAuthResponse(
+      'https://example.chromiumapp.org/#access_token=secret-token&state=attacker',
+      'state-1'
+    );
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(checkTwitchConnection).not.toHaveBeenCalled();
+    expect(rewriteNeedsLoginButton).toHaveBeenCalledWith(false);
+    expect(console.error).toHaveBeenCalledWith('OAuth state mismatch: possible CSRF attack');
   });
 });


### PR DESCRIPTION
## Summary
- fail closed when Twitch OAuth callbacks are missing a non-empty fragment access_token
- avoid logging raw malformed redirect URLs while preserving state mismatch handling
- document login callback failure behavior

Closes #105

## Validation
- npm test
- npm run lint
- git diff --check

## Review
- self-review: passed after preserving existing popup tests
- codex subagent review: APPROVE
- gemini-cli review: blocked locally because sandboxed execution could not write ~/.gemini, and escalated execution was rejected as external diff exfiltration without explicit user approval