### PR TITLE
Validate Twitch channel URL hosts

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -18,29 +18,34 @@ const TWITCH_NON_CHANNEL_PATHS = [
   'clips', 'popout', 'embed', 'chat', 'broadcast'
 ];
 
-// URLがTwitchのチャンネルページかどうかをチェック
-export function isTwitchChannelPage(url) {
-  if (!url || !url.includes('twitch.tv')) return false;
-
+function parseTwitchChannelUrl(url) {
   try {
     const urlObj = new URL(url);
+    if (!['http:', 'https:'].includes(urlObj.protocol)) return null;
+    if (!['twitch.tv', 'www.twitch.tv'].includes(urlObj.hostname)) return null;
+
     const pathParts = urlObj.pathname.split('/').filter(p => p);
 
     // パスがない場合はチャンネルページではない
-    if (pathParts.length === 0) return false;
+    if (pathParts.length === 0) return null;
 
     const firstPath = pathParts[0].toLowerCase();
 
     // システムページの場合はチャンネルページではない
-    if (TWITCH_NON_CHANNEL_PATHS.includes(firstPath)) return false;
+    if (TWITCH_NON_CHANNEL_PATHS.includes(firstPath)) return null;
 
     // チャンネル名として有効かチェック（英数字、アンダースコア、3-25文字）
-    if (!/^[a-z0-9_]{3,25}$/i.test(firstPath)) return false;
+    if (!/^[a-z0-9_]{3,25}$/i.test(firstPath)) return null;
 
-    return true;
+    return firstPath;
   } catch {
-    return false;
+    return null;
   }
+}
+
+// URLがTwitchのチャンネルページかどうかをチェック
+export function isTwitchChannelPage(url) {
+  return parseTwitchChannelUrl(url) !== null;
 }
 
 // Service Workerの再起動に備えてアラームを確認・作成する関数
@@ -352,10 +357,9 @@ async function closeUnwantedTabs(updatedChannels) {
 
   for (const tab of tabs) {
     if (!tab.url) continue;
-    const match = tab.url.match(/https?:\/\/(?:www\.)?twitch\.tv\/([^/?]+)/);
-    if (!match) continue;
+    const channelName = parseTwitchChannelUrl(tab.url);
+    if (!channelName) continue;
 
-    const channelName = match[1].toLowerCase();
     const channel = updatedChannels.find(c => c.name?.toLowerCase() === channelName);
     if (!channel) continue;
 
@@ -402,8 +406,7 @@ export async function displaceNonPriorityTabs(channels) {
     if (!ch.isPriority) continue;
     if (!(await shouldOpenChannel(ch))) continue;
     const hasTab = twitchTabs.some(t => {
-      const m = t.url.match(/twitch\.tv\/([^/?]+)/);
-      return m && m[1].toLowerCase() === ch.name?.toLowerCase();
+      return parseTwitchChannelUrl(t.url) === ch.name?.toLowerCase();
     });
     if (!hasTab) priorityNeedSlots++;
   }
@@ -411,9 +414,8 @@ export async function displaceNonPriorityTabs(channels) {
 
   // 非優先タブを特定して必要数だけ閉じる
   const nonPriorityTabs = twitchTabs.filter(t => {
-    const m = t.url.match(/twitch\.tv\/([^/?]+)/);
-    if (!m) return false;
-    const name = m[1].toLowerCase();
+    const name = parseTwitchChannelUrl(t.url);
+    if (!name) return false;
     const ch = channels.find(c => c.name?.toLowerCase() === name);
     return ch && !ch.isPriority;
   });
@@ -707,9 +709,7 @@ export async function checkOfflineWithTab(tabId) {
   }
 
   // URLからチャンネル名を抽出
-  const urlObj = new URL(tabUrl);
-  const pathParts = urlObj.pathname.split('/').filter(p => p);
-  const channelName = pathParts[0].split('?')[0];
+  const channelName = parseTwitchChannelUrl(tabUrl);
   console.log('channelName', channelName);
 
   const accessToken = migrateOAuthToken((await chrome.storage.local.get('oauth_token')).oauth_token);

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -55,6 +55,12 @@ describe('Background Script', () => {
       expect(isTwitchChannelPage('')).toBe(false);
       expect(isTwitchChannelPage('https://example.com')).toBe(false);
     });
+
+    it('should reject spoofed Twitch hostnames and embedded URLs', () => {
+      expect(isTwitchChannelPage('https://twitch.tv.evil.example/testuser')).toBe(false);
+      expect(isTwitchChannelPage('https://evil.example/path/https://twitch.tv/testuser')).toBe(false);
+      expect(isTwitchChannelPage('https://notwitch.tv/testuser')).toBe(false);
+    });
   });
 
   describe('ensureAlarmsExist', () => {
@@ -1828,6 +1834,7 @@ describe('Background Script', () => {
         { url: 'https://www.twitch.tv/channel1' },
         { url: 'https://www.twitch.tv/channel2' },
         { url: 'https://www.twitch.tv/directory' },
+        { url: 'https://twitch.tv.evil.example/channel3' },
         { url: 'https://www.google.com' },
         { url: null },
       ]);
@@ -2299,6 +2306,72 @@ describe('Background Script', () => {
 
       // Tab should be closed - channel went offline
       expect(chromeMock.tabs.remove).toHaveBeenCalledWith(1);
+    });
+
+    it('should not close non-Twitch tabs with embedded Twitch URLs', async () => {
+      const mockStreamData = {
+        data: [{
+          game_name: 'Valorant',
+          game_id: '516575',
+          title: 'Stream Title',
+          viewer_count: 100,
+          tags: [],
+          user_id: '12345',
+        }],
+      };
+      const mockChannelData = {
+        data: [{ is_branded_content: false }],
+      };
+
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockStreamData),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockChannelData),
+        });
+
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string') {
+          if (keys === 'isEnabledAutoClose') return Promise.resolve({ isEnabledAutoClose: true });
+          if (keys === 'isSkipBrandedContent') return Promise.resolve({ isSkipBrandedContent: false });
+          if (keys === 'lastOpenWindowId') return Promise.resolve({ lastOpenWindowId: 100 });
+          return Promise.resolve({});
+        }
+        if (Array.isArray(keys)) {
+          if (keys.includes('isEnabled')) {
+            return Promise.resolve({
+              isEnabled: true,
+              isEnabledNotifications: false,
+              isOpenMultiTwitch: false,
+              channels: [{ name: 'testchannel', onLive: true, onLiveOpen: true }],
+              oauth_token: 'test_token',
+            });
+          }
+          if (keys.includes('allowedOnlyCategoryList')) {
+            return Promise.resolve({
+              allowedOnlyCategoryList: [],
+              blockedCategoryList: [],
+              blockedCategoryNames: '',
+            });
+          }
+          if (keys.includes('isOpenNewWindow')) {
+            return Promise.resolve({ isOpenNewWindow: false, isEnabledMaxTabs: false });
+          }
+        }
+        return Promise.resolve({});
+      });
+
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://evil.example/path/https://twitch.tv/testchannel', windowId: 100 },
+        { id: 2, url: 'https://twitch.tv.evil.example/testchannel', windowId: 100 },
+      ]);
+
+      await checkStreams();
+
+      expect(chromeMock.tabs.remove).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes #107

## Summary
- add a shared Twitch channel URL parser that requires http/https and exact twitch.tv or www.twitch.tv hosts
- reuse the parser for channel-page checks, auto-close, priority displacement, max-tab counting, and offline tab checks
- add regressions for spoofed hostnames and embedded Twitch URLs

## Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check