### PR TITLE
[codex] Fix context menu channel duplicate casing

### DIFF
--- a/background.js
+++ b/background.js
@@ -96,7 +96,8 @@ chrome.contextMenus.onClicked.addListener(async (info) => {
 
       const data = await chrome.storage.local.get('channels');
       const channels = Array.isArray(data.channels) ? data.channels : [];
-      const index = channels.findIndex((c) => c?.name === channel.name);
+      const normalizedChannelName = channel.name.toLowerCase();
+      const index = channels.findIndex((c) => c?.name?.toLowerCase() === normalizedChannelName);
 
       if (index === -1) {
         const filteredChannels = channels.filter(c => c !== null);

--- a/tests/background-script.test.js
+++ b/tests/background-script.test.js
@@ -85,4 +85,21 @@ describe('background.js context menu channel add', () => {
       ],
     });
   });
+
+  it('does not add a duplicate context menu channel with different casing', async () => {
+    chromeMock.storage.local.get.mockResolvedValue({
+      channels: [
+        { name: 'testuser', categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+      ],
+    });
+    const handler = await loadContextMenuHandler();
+
+    await handler({
+      menuItemId: 'addToMiteruyo',
+      linkUrl: 'https://www.twitch.tv/TestUser',
+    });
+
+    expect(chromeMock.storage.local.set).not.toHaveBeenCalled();
+    expect(backgroundFunctionsMock.checkStreams).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Compare context-menu added channel names case-insensitively before appending
- Preserve existing stored channel casing and append behavior
- Add a regression test for stored testuser blocking context-menu TestUser

Closes #109

## Validation
- npm test
- npm run lint