### PR TITLE
[codex] Fix channel allowed category dropdown duplicates

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -96,6 +96,16 @@ function includesCategory(categories, category) {
   return categories.some(existingCategory => isSameCategory(existingCategory, category));
 }
 
+function getCategoriesNotAlreadyIncluded(categories, existingCategories) {
+  return categories.filter(category => !includesCategory(existingCategories, category));
+}
+
+function addCategoryIfMissing(categories, category) {
+  if (includesCategory(categories, category)) return false;
+  categories.push(category);
+  return true;
+}
+
 // Category search using Twitch API
 async function searchCategories(query) {
   if (!query || query.length < 1) return [];
@@ -1082,17 +1092,11 @@ async function addChannelToList(channel, newAdded = false) {
 
     chrome.storage.local.get('blockedCategoryList', (data) => {
       const categories = normalizeCategoryList(data.blockedCategoryList);
-      categories.forEach(cat => {
-        // Check if already in allowed list (by id or name)
-        const isAlreadyAllowed = currentAllowed.some(c =>
-          (cat.id && c.id === cat.id) || c.name === cat.name
-        );
-        if (!isAlreadyAllowed) {
-          const option = document.createElement('option');
-          option.value = JSON.stringify(cat); // Store full object
-          option.textContent = cat.name;
-          allowDropdown.appendChild(option);
-        }
+      getCategoriesNotAlreadyIncluded(categories, currentAllowed).forEach(cat => {
+        const option = document.createElement('option');
+        option.value = JSON.stringify(cat); // Store full object
+        option.textContent = cat.name;
+        allowDropdown.appendChild(option);
       });
       // Reset to default option
       allowDropdown.selectedIndex = 0;
@@ -1106,11 +1110,7 @@ async function addChannelToList(channel, newAdded = false) {
       const selected = parseCategoryOptionValue(selectedValue);
       if (!selected) return;
 
-      const isAlreadyAllowed = currentAllowed.some(c =>
-        (selected.id && c.id === selected.id) || c.name === selected.name
-      );
-      if (!isAlreadyAllowed) {
-        currentAllowed.push(selected);
+      if (addCategoryIfMissing(currentAllowed, selected)) {
         channel.allowedCategoryList = currentAllowed;
         saveChannelToList(channel);
         renderAllowTags();

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -22,7 +22,7 @@ describe('Popup Script', () => {
 
     vm.createContext(sandbox);
     vm.runInContext(
-      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory };`,
+      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory, getCategoriesNotAlreadyIncluded, addCategoryIfMissing };`,
       sandbox,
       { filename: 'popup.js' }
     );
@@ -274,6 +274,30 @@ describe('Popup Script', () => {
 
     expect(__testExports.isSameCategory(legacyCategory, twitchCategory)).toBe(true);
     expect(__testExports.includesCategory([legacyCategory], twitchCategory)).toBe(true);
+  });
+
+  it('filters channel allowed dropdown options with legacy category matching', async () => {
+    const { __testExports } = await loadPopupTestExports();
+    const currentAllowed = [{ id: null, name: 'Just Chatting' }];
+    const blockedCategories = [
+      { id: '509658', name: 'just chatting' },
+      { id: '26936', name: 'Music' },
+    ];
+
+    expect(__testExports.getCategoriesNotAlreadyIncluded(blockedCategories, currentAllowed)).toEqual([
+      { id: '26936', name: 'Music' },
+    ]);
+  });
+
+  it('does not append channel allowed dropdown selections already matched by legacy category name', async () => {
+    const { __testExports } = await loadPopupTestExports();
+    const currentAllowed = [{ id: null, name: 'Just Chatting' }];
+
+    expect(__testExports.addCategoryIfMissing(currentAllowed, {
+      id: '509658',
+      name: 'just chatting',
+    })).toBe(false);
+    expect(currentAllowed).toEqual([{ id: null, name: 'Just Chatting' }]);
   });
 
   it('does not match unmatched legacy names or empty names', async () => {


### PR DESCRIPTION
## Summary
- Fixes #113.
- Reuses the popup category identity helpers for the channel allowed-category dropdown.
- Prevents legacy missing-id categories from appearing as duplicate dropdown options or being appended again with different casing.

## Validation
- npm test -- tests/popup.test.js
- npm test
- npm run lint
- git diff --check