### PR TITLE
Fix equivalent category tag deletion

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -106,6 +106,10 @@ function addCategoryIfMissing(categories, category) {
   return true;
 }
 
+function removeMatchingCategories(categories, category) {
+  return categories.filter(existingCategory => !isSameCategory(existingCategory, category));
+}
+
 // Category search using Twitch API
 async function searchCategories(query) {
   if (!query || query.length < 1) return [];
@@ -465,7 +469,7 @@ function renderGlobalAllowedOnlyTags() {
     categories: globalAllowedOnlyCategories,
     badgeClass: 'bg-success',
     onDelete: (cat) => {
-      globalAllowedOnlyCategories = globalAllowedOnlyCategories.filter(c => c.id !== cat.id || c.name !== cat.name);
+      globalAllowedOnlyCategories = removeMatchingCategories(globalAllowedOnlyCategories, cat);
       chrome.storage.local.set({ allowedOnlyCategoryList: globalAllowedOnlyCategories });
       renderGlobalAllowedOnlyTags();
       globalAllowedOnlyCategorySearch?.updateExistingCategories(globalAllowedOnlyCategories);
@@ -494,7 +498,7 @@ function renderGlobalBlockedTags() {
     categories: globalBlockedCategories,
     badgeClass: 'bg-danger',
     onDelete: (cat) => {
-      globalBlockedCategories = globalBlockedCategories.filter(c => c.id !== cat.id || c.name !== cat.name);
+      globalBlockedCategories = removeMatchingCategories(globalBlockedCategories, cat);
       chrome.storage.local.set({ blockedCategoryList: globalBlockedCategories });
       renderGlobalBlockedTags();
       globalCategorySearch?.updateExistingCategories(globalBlockedCategories);
@@ -1074,7 +1078,7 @@ async function addChannelToList(channel, newAdded = false) {
       categories: currentAllowed,
       badgeClass: 'bg-success',
       onDelete: (cat) => {
-        currentAllowed = currentAllowed.filter(c => c.id !== cat.id || c.name !== cat.name);
+        currentAllowed = removeMatchingCategories(currentAllowed, cat);
         channel.allowedCategoryList = currentAllowed;
         saveChannelToList(channel);
         renderAllowTags();
@@ -1184,7 +1188,7 @@ async function addChannelToList(channel, newAdded = false) {
       categories: currentAllowedOnly,
       badgeClass: 'bg-primary',
       onDelete: (cat) => {
-        currentAllowedOnly = currentAllowedOnly.filter(c => c.id !== cat.id || c.name !== cat.name);
+        currentAllowedOnly = removeMatchingCategories(currentAllowedOnly, cat);
         channel.allowedOnlyCategoryList = currentAllowedOnly;
         saveChannelToList(channel);
         renderAllowedOnlyTags();
@@ -1291,7 +1295,7 @@ async function addChannelToList(channel, newAdded = false) {
       categories: channelBlockedCategories,
       badgeClass: 'bg-danger',
       onDelete: (cat) => {
-        channelBlockedCategories = channelBlockedCategories.filter(c => c.id !== cat.id || c.name !== cat.name);
+        channelBlockedCategories = removeMatchingCategories(channelBlockedCategories, cat);
         channel.blockedCategoryList = channelBlockedCategories;
         saveChannelToList(channel);
         renderCatTags();

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -22,7 +22,7 @@ describe('Popup Script', () => {
 
     vm.createContext(sandbox);
     vm.runInContext(
-      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory, getCategoriesNotAlreadyIncluded, addCategoryIfMissing };`,
+      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory, getCategoriesNotAlreadyIncluded, addCategoryIfMissing, removeMatchingCategories };`,
       sandbox,
       { filename: 'popup.js' }
     );
@@ -298,6 +298,39 @@ describe('Popup Script', () => {
       name: 'just chatting',
     })).toBe(false);
     expect(currentAllowed).toEqual([{ id: null, name: 'Just Chatting' }]);
+  });
+
+  it('removes equivalent legacy and Twitch category tags together', async () => {
+    const { __testExports } = await loadPopupTestExports();
+    const categories = [
+      { id: null, name: 'Just Chatting' },
+      { id: '509658', name: 'just chatting' },
+      { id: '26936', name: 'Music' },
+    ];
+
+    expect(__testExports.removeMatchingCategories(categories, {
+      id: '509658',
+      name: 'Just Chatting',
+    })).toEqual([
+      { id: '26936', name: 'Music' },
+    ]);
+  });
+
+  it('keeps same-name categories with different Twitch ids when removing category tags', async () => {
+    const { __testExports } = await loadPopupTestExports();
+    const categories = [
+      { id: '509658', name: 'Just Chatting' },
+      { id: '123', name: 'Just Chatting' },
+      { id: null, name: 'Music' },
+    ];
+
+    expect(__testExports.removeMatchingCategories(categories, {
+      id: '509658',
+      name: 'Just Chatting',
+    })).toEqual([
+      { id: '123', name: 'Just Chatting' },
+      { id: null, name: 'Music' },
+    ]);
   });
 
   it('does not match unmatched legacy names or empty names', async () => {


### PR DESCRIPTION
Closes #115.

## Summary
- add a shared category deletion helper that uses the existing category equivalence semantics
- apply it to global allowed-only, global blocked, channel allowed exceptions, channel allowed-only, and channel blocked tag deletion
- add popup regression coverage for removing legacy/Twitch-equivalent tags while preserving same-name categories with different Twitch ids

## Validation
- npm test -- tests/popup.test.js
- npm test
- npm run lint
- git diff --check