### PR TITLE
Fix open-new-window channel casing duplicate

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -43,6 +43,27 @@ function parseTwitchChannelUrl(url) {
   }
 }
 
+function isMatchingChannelTabUrl(tabUrl, targetURL) {
+  if (!tabUrl || !tabUrl.startsWith('http')) {
+    return false;
+  }
+
+  const tabChannelName = parseTwitchChannelUrl(tabUrl);
+  const targetChannelName = parseTwitchChannelUrl(targetURL);
+  if (tabChannelName && targetChannelName) {
+    return tabChannelName === targetChannelName;
+  }
+
+  try {
+    // 既存のタブのURLからクエリパラメータを除去
+    const tabURLWithoutQuery = new URL(tabUrl);
+    tabURLWithoutQuery.search = '';
+    return tabURLWithoutQuery.toString() === targetURL;
+  } catch {
+    return false;
+  }
+}
+
 // URLがTwitchのチャンネルページかどうかをチェック
 export function isTwitchChannelPage(url) {
   return parseTwitchChannelUrl(url) !== null;
@@ -658,7 +679,7 @@ export async function channelQueuedStreams(channelQueue) {
           // 新しいウィンドウを作成する必要がある
           const tabs = await chrome.tabs.query({});
           const targetURL = channelURL(channel);
-          const matchingTabs = tabs.filter(tab => tab.url === targetURL);
+          const matchingTabs = tabs.filter(tab => isMatchingChannelTabUrl(tab.url, targetURL));
 
           if (matchingTabs.length === 0) {
             console.log('openNewWindow', { targetURL, matchingTabs: matchingTabs.length });
@@ -839,21 +860,7 @@ async function openTabIfNotExists(channel, windowId = null) {
   const targetURL = channelURL(channel);
   console.log('openTabIfNotExists', { targetURL, windowId });
   const tabs = await chrome.tabs.query({});
-  const matchingTabs = tabs.filter(tab => {
-    // タブのURLが無効な場合はスキップ（chrome://、about:blank など）
-    if (!tab.url || !tab.url.startsWith('http')) {
-      return false;
-    }
-    try {
-      // 既存のタブのURLからクエリパラメータを除去
-      const tabURLWithoutQuery = new URL(tab.url);
-      tabURLWithoutQuery.search = '';
-      return tabURLWithoutQuery.toString() === targetURL; // クエリパラメータを除去したURLで比較
-    } catch {
-      // 無効なURLの場合はスキップ
-      return false;
-    }
-  });
+  const matchingTabs = tabs.filter(tab => isMatchingChannelTabUrl(tab.url, targetURL));
 
   if (matchingTabs.length === 0) {
     await chrome.tabs.create({ url: targetURL, windowId });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1754,6 +1754,98 @@ describe('Background Script', () => {
     });
   });
 
+  describe('channelQueuedStreams open-new-window duplicate checks', () => {
+    function mockOpenNewWindowStorage() {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (Array.isArray(keys) && keys.includes('isOpenNewWindow')) {
+          return Promise.resolve({
+            isOpenNewWindow: true,
+            isEnabledMaxTabs: false,
+            maxTabCount: 5,
+          });
+        }
+        if (keys === 'lastOpenWindowId') {
+          return Promise.resolve({ lastOpenWindowId: 999 });
+        }
+        if (keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        if (Array.isArray(keys) && keys.includes('allowedOnlyCategoryList')) {
+          return Promise.resolve({
+            allowedOnlyCategoryList: [],
+            blockedCategoryList: [],
+            blockedCategoryNames: '',
+          });
+        }
+        return Promise.resolve({});
+      });
+    }
+
+    it('should not create a new window when an existing Twitch channel tab differs only by casing', async () => {
+      const channels = [
+        { name: 'TestUser', onLive: true, onLiveOpen: true },
+      ];
+
+      mockOpenNewWindowStorage();
+      chromeMock.windows.get.mockRejectedValue(new Error('Window not found'));
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://www.twitch.tv/testuser', windowId: 100 },
+      ]);
+
+      await channelQueuedStreams(channels);
+
+      expect(chromeMock.windows.create).not.toHaveBeenCalled();
+      expect(chromeMock.storage.local.set).not.toHaveBeenCalledWith({ channels });
+      expect(channels[0].hasBeenOpened).toBeUndefined();
+    });
+
+    it('should create a new window when no casing-equivalent Twitch channel tab exists', async () => {
+      const channels = [
+        { name: 'TestUser', onLive: true, onLiveOpen: true },
+      ];
+
+      mockOpenNewWindowStorage();
+      chromeMock.windows.get.mockRejectedValue(new Error('Window not found'));
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://www.twitch.tv/otheruser', windowId: 100 },
+      ]);
+      chromeMock.windows.create.mockResolvedValue({ id: 200 });
+
+      await channelQueuedStreams(channels);
+
+      expect(chromeMock.windows.create).toHaveBeenCalledWith({
+        url: 'https://www.twitch.tv/TestUser',
+      });
+      expect(chromeMock.storage.local.set).toHaveBeenCalledWith({ lastOpenWindowId: 200 });
+      expect(chromeMock.storage.local.set).toHaveBeenCalledWith({ channels });
+      expect(channels[0].hasBeenOpened).toBe(true);
+    });
+
+    it('should preserve exact URL matching for custom non-Twitch channel URLs', async () => {
+      const channels = [
+        {
+          name: 'TestUser',
+          url: 'https://example.com/TestUser',
+          onLive: true,
+          onLiveOpen: true,
+        },
+      ];
+
+      mockOpenNewWindowStorage();
+      chromeMock.windows.get.mockRejectedValue(new Error('Window not found'));
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://example.com/testuser', windowId: 100 },
+      ]);
+      chromeMock.windows.create.mockResolvedValue({ id: 200 });
+
+      await channelQueuedStreams(channels);
+
+      expect(chromeMock.windows.create).toHaveBeenCalledWith({
+        url: 'https://example.com/TestUser',
+      });
+    });
+  });
+
   describe('openInManagedWindow', () => {
     it('should open tab in current window when isOpenNewWindow is false', async () => {
       chromeMock.storage.local.get.mockResolvedValue({


### PR DESCRIPTION
Summary
- Add shared channel-tab URL matching that compares structural Twitch channel URLs case-insensitively.
- Use it for the open-new-window fallback duplicate check and the regular tab-open duplicate guard.
- Add background regressions for casing-equivalent Twitch tabs and custom non-Twitch URL behavior.

Issues: Closes #119

Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check