### PR TITLE
fix: normalize channelName to lowercase to prevent duplicate tabs

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -102,7 +102,7 @@ export async function ensureAlarmsExist() {
 
 // Miteruyoの管理対象ウィンドウでタブを開く
 export async function openInManagedWindow(channelName) {
-  const url = twitchDomain + '/' + channelName;
+  const url = twitchDomain + '/' + channelName.toLowerCase();
   const data = await chrome.storage.local.get(['isOpenNewWindow', 'lastOpenWindowId']);
 
   if (data.isOpenNewWindow) {


### PR DESCRIPTION
## Summary
Fixes azumag/miteruyo#121 - channel tabs duplicated when opened with different casing.

## Root Cause
`openInManagedWindow` constructed URLs without lowercasing the `channelName`:
```javascript
const url = twitchDomain + '/' + channelName;  // Could be 'SomeChannel'
```

But `parseTwitchChannelUrl` always returns lowercase. This caused `isMatchingChannelTabUrl` to fail matching tabs opened with different casing, leading to duplicate tabs.

## Fix
```javascript
const url = twitchDomain + '/' + channelName.toLowerCase();
```

## Verification
- ✅ JavaScript syntax check passed
- Surgical change: only 1 line modified
- Follows existing code patterns

Fixes #121