### PR TITLE
Fix managed window channel casing duplicates

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -118,8 +118,8 @@ export async function openInManagedWindow(channelName) {
     }
 
     if (windowId) {
-      // 既存の管理対象ウィンドウにタブを追加
-      await chrome.tabs.create({ url, windowId });
+      // 既存の管理対象ウィンドウに重複がなければタブを追加
+      await openTabIfNotExists({ name: channelName }, windowId);
     } else {
       // 新しいウィンドウを作成して管理対象に登録
       const newWindow = await chrome.windows.create({ url });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1890,11 +1890,47 @@ describe('Background Script', () => {
       });
       // checkWindowExists calls windows.get with { populate: false }
       chromeMock.windows.get.mockResolvedValue({ id: 123 });
+      chromeMock.tabs.query.mockResolvedValue([]);
 
       await openInManagedWindow('testchannel');
 
       expect(chromeMock.tabs.create).toHaveBeenCalledWith({
         url: 'https://www.twitch.tv/testchannel',
+        windowId: 123,
+      });
+      expect(chromeMock.windows.create).not.toHaveBeenCalled();
+    });
+
+    it('should not add a duplicate casing-equivalent Twitch tab to an existing managed window', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        isOpenNewWindow: true,
+        lastOpenWindowId: 123,
+      });
+      chromeMock.windows.get.mockResolvedValue({ id: 123 });
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://www.twitch.tv/testchannel', windowId: 123 },
+      ]);
+
+      await openInManagedWindow('TestChannel');
+
+      expect(chromeMock.tabs.create).not.toHaveBeenCalled();
+      expect(chromeMock.windows.create).not.toHaveBeenCalled();
+    });
+
+    it('should add a tab to an existing managed window when no matching channel tab exists', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        isOpenNewWindow: true,
+        lastOpenWindowId: 123,
+      });
+      chromeMock.windows.get.mockResolvedValue({ id: 123 });
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://www.twitch.tv/otherchannel', windowId: 123 },
+      ]);
+
+      await openInManagedWindow('TestChannel');
+
+      expect(chromeMock.tabs.create).toHaveBeenCalledWith({
+        url: 'https://www.twitch.tv/TestChannel',
         windowId: 123,
       });
       expect(chromeMock.windows.create).not.toHaveBeenCalled();


### PR DESCRIPTION
Summary
- Route existing managed-window opens through the shared duplicate-tab guard
- Prevent casing-equivalent Twitch channel tabs from being added again
- Add background regressions for duplicate and non-duplicate managed-window opens

Issues: Closes #121

Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check