### PR TITLE
fix: use case-insensitive channel name for tab rotation deduplication

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -164,11 +164,12 @@ export async function checkTabRotate() {
     const tabsToRemove = [];
     for (const tab of tabs) {
       if (!tab.url || !tab.url.startsWith('http')) continue;
-      const urlWithoutQuery = tab.url.split('?')[0];
-      if (seenUrls.has(urlWithoutQuery)) {
+      const channelName = parseTwitchChannelUrl(tab.url);
+      const dedupKey = channelName || tab.url.split('?')[0];
+      if (seenUrls.has(dedupKey)) {
         tabsToRemove.push(tab.id);
       } else {
-        seenUrls.add(urlWithoutQuery);
+        seenUrls.add(dedupKey);
       }
     }
     if (tabsToRemove.length > 0) {


### PR DESCRIPTION
## What
checkTabRotate() now uses parseTwitchChannelUrl() to get the lowercase channel name as the deduplication key for Twitch tabs, instead of the full URL. This means 'TestUser' and 'testuser' tabs are recognized as duplicates during tab rotation.

## Why
The tab rotation deduplication logic used urlWithoutQuery (URL with query params stripped) as the key. Twitch channel URLs with different casing (e.g. /TestUser vs /testuser) were treated as different URLs, allowing casing-equivalent duplicate tabs to survive tab rotation.

## How
In the for loop of checkTabRotate(), added:
```js
const channelName = parseTwitchChannelUrl(tab.url);
const dedupKey = channelName || tab.url.split('?')[0];
```
Then use dedupKey instead of urlWithoutQuery. For Twitch channel URLs, channelName is the lowercase channel name; for all other URLs, it falls back to urlWithoutQuery.

## Testing
All149 existing tests pass (npm test).

Fixes #125