### PR TITLE
Fix tab rotation channel casing dedupe

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -164,11 +164,12 @@ export async function checkTabRotate() {
     const tabsToRemove = [];
     for (const tab of tabs) {
       if (!tab.url || !tab.url.startsWith('http')) continue;
-      const urlWithoutQuery = tab.url.split('?')[0];
-      if (seenUrls.has(urlWithoutQuery)) {
+      const channelName = parseTwitchChannelUrl(tab.url);
+      const dedupKey = channelName || tab.url.split('?')[0];
+      if (seenUrls.has(dedupKey)) {
         tabsToRemove.push(tab.id);
       } else {
-        seenUrls.add(urlWithoutQuery);
+        seenUrls.add(dedupKey);
       }
     }
     if (tabsToRemove.length > 0) {

--- a/background-functions.js
+++ b/background-functions.js
@@ -158,8 +158,8 @@ export async function checkTabRotate() {
     chrome.tabs.update(tabs[currentTabIndex].id, { muted: enableTabMute });
     chrome.tabs.update(tabs[nextTabIndex].id, { active: true, muted: false });
 
-    // Close duplicate tabs
-    // Deduplicate tabs based on URL without query parameters
+    // Close duplicate tabs. Twitch channel pages use channel identity;
+    // other URLs keep the existing URL-without-query behavior.
     const seenUrls = new Set();
     const tabsToRemove = [];
     for (const tab of tabs) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1448,6 +1448,64 @@ describe('Background Script', () => {
         expect(chromeMock.tabs.update).toHaveBeenCalledWith(2, { active: true, muted: false });
       });
 
+      it('should remove casing-equivalent Twitch channel tabs during rotation', async () => {
+        const windowId = 123;
+        const tabs = [
+          { id: 1, url: 'https://www.twitch.tv/TestUser', active: true },
+          { id: 2, url: 'https://www.twitch.tv/anotheruser', active: false },
+          { id: 3, url: 'https://www.twitch.tv/testuser', active: false },
+        ];
+
+        chromeMock.storage.local.get.mockImplementation((key) => {
+          if (key === 'isEnabledTabRotation') {
+            return Promise.resolve({ isEnabledTabRotation: true });
+          }
+          if (key === 'lastOpenWindowId') {
+            return Promise.resolve({ lastOpenWindowId: windowId });
+          }
+          if (key === 'isEnabledTabMute') {
+            return Promise.resolve({ isEnabledTabMute: false });
+          }
+          return Promise.resolve({});
+        });
+
+        chromeMock.windows.get.mockResolvedValue({ id: windowId });
+        chromeMock.tabs.query.mockResolvedValue(tabs);
+
+        await checkTabRotate();
+
+        expect(chromeMock.tabs.remove).toHaveBeenCalledWith([3]);
+      });
+
+      it('should keep non-Twitch tabs with casing-different paths during rotation', async () => {
+        const windowId = 123;
+        const tabs = [
+          { id: 1, url: 'https://example.com/TestUser', active: true },
+          { id: 2, url: 'https://example.com/testuser', active: false },
+          { id: 3, url: 'https://example.com/TestUser?ref=duplicate', active: false },
+        ];
+
+        chromeMock.storage.local.get.mockImplementation((key) => {
+          if (key === 'isEnabledTabRotation') {
+            return Promise.resolve({ isEnabledTabRotation: true });
+          }
+          if (key === 'lastOpenWindowId') {
+            return Promise.resolve({ lastOpenWindowId: windowId });
+          }
+          if (key === 'isEnabledTabMute') {
+            return Promise.resolve({ isEnabledTabMute: false });
+          }
+          return Promise.resolve({});
+        });
+
+        chromeMock.windows.get.mockResolvedValue({ id: windowId });
+        chromeMock.tabs.query.mockResolvedValue(tabs);
+
+        await checkTabRotate();
+
+        expect(chromeMock.tabs.remove).toHaveBeenCalledWith([3]);
+      });
+
       it('should clear lastOpenWindowId when window does not exist', async () => {
         const windowId = 123;
 


### PR DESCRIPTION
## Summary
- use parsed Twitch channel identity when tab rotation deduplicates managed-window tabs
- preserve the existing URL-without-query fallback for non-Twitch tabs
- add regression coverage for casing-equivalent Twitch duplicates and non-Twitch fallback behavior

Issues: Closes #125

## Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check