### PR TITLE
Fix priority displacement channel name guards

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -43,6 +43,10 @@ function parseTwitchChannelUrl(url) {
   }
 }
 
+function normalizeChannelName(name) {
+  return typeof name === 'string' ? name.toLowerCase() : null;
+}
+
 function isMatchingChannelTabUrl(tabUrl, targetURL) {
   if (!tabUrl || !tabUrl.startsWith('http')) {
     return false;
@@ -382,7 +386,7 @@ async function closeUnwantedTabs(updatedChannels) {
     const channelName = parseTwitchChannelUrl(tab.url);
     if (!channelName) continue;
 
-    const channel = updatedChannels.find(c => c.name?.toLowerCase() === channelName);
+    const channel = updatedChannels.find(c => normalizeChannelName(c?.name) === channelName);
     if (!channel) continue;
 
     // オフラインのチャンネルは閉じる
@@ -427,8 +431,10 @@ export async function displaceNonPriorityTabs(channels) {
     if (!ch) continue;
     if (!ch.isPriority) continue;
     if (!(await shouldOpenChannel(ch))) continue;
+    const normalizedChannelName = normalizeChannelName(ch.name);
+    if (!normalizedChannelName) continue;
     const hasTab = twitchTabs.some(t => {
-      return parseTwitchChannelUrl(t.url) === ch.name?.toLowerCase();
+      return parseTwitchChannelUrl(t.url) === normalizedChannelName;
     });
     if (!hasTab) priorityNeedSlots++;
   }
@@ -438,7 +444,7 @@ export async function displaceNonPriorityTabs(channels) {
   const nonPriorityTabs = twitchTabs.filter(t => {
     const name = parseTwitchChannelUrl(t.url);
     if (!name) return false;
-    const ch = channels.find(c => c.name?.toLowerCase() === name);
+    const ch = channels.find(c => normalizeChannelName(c?.name) === name);
     return ch && !ch.isPriority;
   });
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -2788,6 +2788,40 @@ describe('Background Script', () => {
         // No displacement needed - priority channel already open
         expect(chromeMock.tabs.remove).not.toHaveBeenCalled();
       });
+
+      it('should ignore malformed channel names when displacing tabs', async () => {
+        const channels = [
+          { name: 123, onLive: true, onLiveOpen: true, isPriority: true },
+          { name: { value: 'broken' }, onLive: true, onLiveOpen: true, isPriority: false },
+          { name: 'PriorityOne', onLive: true, onLiveOpen: true, isPriority: true },
+          { name: 'nonpriority1', onLive: true, onLiveOpen: true, isPriority: false },
+        ];
+
+        chromeMock.storage.local.get.mockImplementation((keys) => {
+          if (Array.isArray(keys) && keys.includes('isEnabledMaxTabs')) {
+            return Promise.resolve({ isEnabledMaxTabs: true, maxTabCount: 2, lastOpenWindowId: null });
+          }
+          if (Array.isArray(keys) && keys.includes('allowedOnlyCategoryList')) {
+            return Promise.resolve({
+              allowedOnlyCategoryList: [],
+              blockedCategoryList: [],
+              blockedCategoryNames: '',
+            });
+          }
+          return Promise.resolve({});
+        });
+
+        chromeMock.tabs.query.mockResolvedValue([
+          { id: 1, url: 'https://www.twitch.tv/nonpriority1' },
+          { id: 2, url: 'https://www.twitch.tv/nonpriority2' },
+        ]);
+        chromeMock.tabs.remove.mockResolvedValue();
+
+        await displaceNonPriorityTabs(channels);
+
+        expect(chromeMock.tabs.remove).toHaveBeenCalledTimes(1);
+        expect(chromeMock.tabs.remove).toHaveBeenCalledWith(1);
+      });
     });
   });
 


### PR DESCRIPTION
Summary
- Add a background channel-name normalizer before lowercasing stored channel names.
- Use it in priority tab displacement and related tab/channel lookup paths so malformed non-string names are ignored instead of crashing.
- Add regression coverage for malformed channel names while preserving mixed-case priority matching and non-priority displacement.

Issues: Closes #128

Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check