### PR TITLE
Fix context menu channel name normalization

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,6 +12,10 @@ import {
   onNotificationClicked,
 } from './background-functions.js';
 
+function normalizeChannelName(name) {
+  return typeof name === 'string' ? name.toLowerCase() : null;
+}
+
 // Service Worker起動時にもアラームを確認（フォールバック）
 ensureAlarmsExist().catch(e => console.error('ensureAlarmsExist error:', e));
 
@@ -96,8 +100,8 @@ chrome.contextMenus.onClicked.addListener(async (info) => {
 
       const data = await chrome.storage.local.get('channels');
       const channels = Array.isArray(data.channels) ? data.channels : [];
-      const normalizedChannelName = channel.name.toLowerCase();
-      const index = channels.findIndex((c) => c?.name?.toLowerCase() === normalizedChannelName);
+      const normalizedChannelName = normalizeChannelName(channel.name);
+      const index = channels.findIndex((c) => normalizeChannelName(c?.name) === normalizedChannelName);
 
       if (index === -1) {
         const filteredChannels = channels.filter(c => c !== null);

--- a/tests/background-script.test.js
+++ b/tests/background-script.test.js
@@ -86,6 +86,31 @@ describe('background.js context menu channel add', () => {
     });
   });
 
+  it('ignores malformed stored channel names when appending a new context menu channel', async () => {
+    chromeMock.storage.local.get.mockResolvedValue({
+      channels: [
+        null,
+        { name: 123, categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+        { name: {}, categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+      ],
+    });
+    const handler = await loadContextMenuHandler();
+
+    await handler({
+      menuItemId: 'addToMiteruyo',
+      linkUrl: 'https://www.twitch.tv/NewChannel',
+    });
+
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+      channels: [
+        { name: 123, categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+        { name: {}, categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+        { name: 'NewChannel', categoriesFilter: '', tagsFilter: '', onLiveOpen: true },
+      ],
+    });
+    expect(backgroundFunctionsMock.checkStreams).toHaveBeenCalledTimes(1);
+  });
+
   it('does not add a duplicate context menu channel with different casing', async () => {
     chromeMock.storage.local.get.mockResolvedValue({
       channels: [


### PR DESCRIPTION
## Summary
- add a string-only channel name normalizer for the background context-menu add flow
- ignore malformed stored channel names during duplicate checks while preserving valid case-insensitive duplicate detection
- add regression coverage for non-string stored channel names

## Issues
Closes #130

## Validation
- npm test -- tests/background-script.test.js
- npm test
- npm run lint
- git diff --check