### PR TITLE
Fix category matching for malformed game names

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -224,6 +224,10 @@ function normalizeCategoryList(categories) {
     );
 }
 
+function normalizeCategoryName(name) {
+  return typeof name === 'string' ? name.toLowerCase() : null;
+}
+
 export async function validateToken(token) {
   try {
     const response = await fetch('https://id.twitch.tv/oauth2/validate', {
@@ -573,7 +577,7 @@ export async function shouldOpenChannel(channel, { forAutoClose = false } = {}) 
     }
 
     const gameId = channel.game_id;
-    const gameName = channel.game_name?.toLowerCase();
+    const gameName = normalizeCategoryName(channel.game_name);
 
     const isInAllowedOnly = activeAllowedOnlyList.some(cat =>
       (gameId && cat.id && cat.id === gameId) ||
@@ -611,7 +615,7 @@ export async function shouldOpenChannel(channel, { forAutoClose = false } = {}) 
 
   if (combinedBlockedList.length > 0 && (channel.game_id || channel.game_name)) {
     const gameId = channel.game_id;
-    const gameName = channel.game_name?.toLowerCase();
+    const gameName = normalizeCategoryName(channel.game_name);
 
     // Check if this category is explicitly allowed for this channel (by id first, then name)
     const isAllowed = allowedCategoryList.some(cat =>

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -982,6 +982,52 @@ describe('Background Script', () => {
 
       expect(result).toBe(true);
     });
+
+    it('should ignore non-string game names without throwing when category filters use names', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string' && keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        return Promise.resolve({
+          allowedOnlyCategoryList: [{ id: null, name: 'Allowed Game' }],
+          blockedCategoryList: [],
+          blockedCategoryNames: '',
+        });
+      });
+
+      const result = await shouldOpenChannel({
+        name: 'test',
+        onLive: true,
+        onLiveOpen: true,
+        game_name: { broken: true },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should still match category filters by game id when game name is non-string', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string' && keys === 'isSkipBrandedContent') {
+          return Promise.resolve({ isSkipBrandedContent: false });
+        }
+        return Promise.resolve({
+          allowedOnlyCategoryList: [],
+          blockedCategoryList: [{ id: '123', name: 'Blocked Game' }],
+          blockedCategoryNames: '',
+        });
+      });
+
+      const result = await shouldOpenChannel({
+        name: 'test',
+        onLive: true,
+        onLiveOpen: true,
+        game_id: '123',
+        game_name: 123,
+        allowedCategoryList: [{ id: '123', name: 'Allowed Game' }],
+      });
+
+      expect(result).toBe(true);
+    });
   });
 
   describe('tabRotationAlarm', () => {


### PR DESCRIPTION
Summary
- Add a category-name normalization helper so shouldOpenChannel only lowercases string game_name values.
- Preserve ID-first category matching when game_name is malformed.
- Add regressions for allowed-only and blocked/allowed override paths with non-string game_name values.

Issues: Closes #132

Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check