### PR TITLE
Fix MultiTwitch channel name filtering

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -47,6 +47,12 @@ function normalizeChannelName(name) {
   return typeof name === 'string' ? name.toLowerCase() : null;
 }
 
+function normalizeMultiTwitchChannelName(name) {
+  if (typeof name !== 'string') return null;
+  const trimmedName = name.trim();
+  return /^[a-z0-9_]{3,25}$/i.test(trimmedName) ? trimmedName : null;
+}
+
 function isMatchingChannelTabUrl(tabUrl, targetURL) {
   if (!tabUrl || !tabUrl.startsWith('http')) {
     return false;
@@ -501,7 +507,11 @@ export async function channelQueuedStreamsInMultiTwitch() {
   if (liveChannels.length === 0) return;
 
   // MultiTwitch URLの作成
-  const channelNames = liveChannels.map(c => c.name).join('/');
+  const channelNames = liveChannels
+    .map(c => normalizeMultiTwitchChannelName(c.name))
+    .filter(Boolean)
+    .join('/');
+  if (!channelNames) return;
   const multiTwitchUrl = `https://multitwitch.tv/${channelNames}`;
 
   // すでに開いているウィンドウか新しいウィンドウで開く

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -346,6 +346,51 @@ describe('Background Script', () => {
         windowId: 10,
       });
     });
+
+    it('should ignore live channels with invalid names when building the MultiTwitch URL', async () => {
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (Array.isArray(keys) && keys.includes('channels')) {
+          return Promise.resolve({
+            isEnabled: true,
+            channels: [
+              { name: 'first', onLive: true, onLiveOpen: true },
+              { name: 123, onLive: true, onLiveOpen: true },
+              { name: { value: 'broken' }, onLive: true, onLiveOpen: true },
+              { onLive: true, onLiveOpen: true },
+              { name: 'second', onLive: true, onLiveOpen: true },
+            ],
+          });
+        }
+        if (keys === 'lastOpenWindowId') {
+          return Promise.resolve({ lastOpenWindowId: 10 });
+        }
+        return Promise.resolve({});
+      });
+      chromeMock.tabs.query.mockResolvedValue([]);
+
+      await channelQueuedStreamsInMultiTwitch();
+
+      expect(chromeMock.tabs.create).toHaveBeenCalledWith({
+        url: 'https://multitwitch.tv/first/second',
+        windowId: 10,
+      });
+    });
+
+    it('should not open MultiTwitch when every live channel has an invalid name', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        isEnabled: true,
+        channels: [
+          { name: 123, onLive: true, onLiveOpen: true },
+          { name: { value: 'broken' }, onLive: true, onLiveOpen: true },
+          { onLive: true, onLiveOpen: true },
+        ],
+      });
+
+      await channelQueuedStreamsInMultiTwitch();
+
+      expect(chromeMock.tabs.query).not.toHaveBeenCalled();
+      expect(chromeMock.tabs.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('API response error handling', () => {


### PR DESCRIPTION
Summary
- Filter MultiTwitch channel URL segments through a string-only Twitch channel name validator.
- Skip malformed live/open channel entries instead of stringifying them into the MultiTwitch URL.
- Avoid opening MultiTwitch when no valid channel names remain.

Issues: Closes #134

Validation
- npm test -- tests/background.test.js
- npm test
- npm run lint
- git diff --check
