### PR TITLE
[codex] Fix auto-open queue invalid channel names

### DIFF
--- a/background-functions.js
+++ b/background-functions.js
@@ -682,6 +682,8 @@ export async function channelQueuedStreams(channelQueue) {
       if (isEnabledMaxTabs) {
         if (currentTabCount >= max) break;
       }
+      const targetURL = channelURL(channel);
+      if (!targetURL) continue;
       if (await shouldOpenChannel(channel)) {
         console.log('channelQueueStreams', { currentWindowId });
 
@@ -699,7 +701,6 @@ export async function channelQueuedStreams(channelQueue) {
         } else {
           // 新しいウィンドウを作成する必要がある
           const tabs = await chrome.tabs.query({});
-          const targetURL = channelURL(channel);
           const matchingTabs = tabs.filter(tab => isMatchingChannelTabUrl(tab.url, targetURL));
 
           if (matchingTabs.length === 0) {
@@ -721,6 +722,7 @@ export async function channelQueuedStreams(channelQueue) {
       if (isEnabledMaxTabs) {
         if (currentTabCount >= max) break;
       }
+      if (!channelURL(channel)) continue;
       if (await shouldOpenChannel(channel)) {
         const wasOpened = await openTabIfNotExists(channel);
         if (wasOpened) {
@@ -865,7 +867,9 @@ function shuffleArray(arr) {
 
 function channelURL(channel) {
   if (channel.url) return channel.url;
-  return twitchDomain + '/' + channel.name;
+  const channelName = normalizeMultiTwitchChannelName(channel.name);
+  if (!channelName) return null;
+  return twitchDomain + '/' + channelName;
 }
 
 async function checkWindowExists(windowId) {
@@ -879,6 +883,7 @@ async function checkWindowExists(windowId) {
 
 async function openTabIfNotExists(channel, windowId = null) {
   const targetURL = channelURL(channel);
+  if (!targetURL) return false;
   console.log('openTabIfNotExists', { targetURL, windowId });
   const tabs = await chrome.tabs.query({});
   const matchingTabs = tabs.filter(tab => isMatchingChannelTabUrl(tab.url, targetURL));

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -2290,6 +2290,92 @@ describe('Background Script', () => {
       expect(chromeMock.tabs.create).toHaveBeenCalledTimes(2);
     });
 
+    it('should skip invalid channel names while opening valid queued channels', async () => {
+      const channels = [
+        { name: 123, onLive: true, onLiveOpen: true, isPriority: true },
+        { onLive: true, onLiveOpen: true, isPriority: true },
+        { name: '', onLive: true, onLiveOpen: true, isPriority: true },
+        { name: { value: 'bad' }, onLive: true, onLiveOpen: true, isPriority: true },
+        { name: 'valid_channel', onLive: true, onLiveOpen: true, isPriority: true },
+      ];
+
+      let existingTabs = [];
+      chromeMock.tabs.query.mockImplementation(() => Promise.resolve([...existingTabs]));
+      chromeMock.tabs.create.mockImplementation(({ url }) => {
+        const newTab = { url, id: existingTabs.length + 1 };
+        existingTabs.push(newTab);
+        return Promise.resolve(newTab);
+      });
+
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (Array.isArray(keys) && keys.includes('isOpenNewWindow')) {
+          return Promise.resolve({ isOpenNewWindow: false, isEnabledMaxTabs: false });
+        }
+        if (Array.isArray(keys) && keys.includes('allowedOnlyCategoryList')) {
+          return Promise.resolve({
+            allowedOnlyCategoryList: [],
+            blockedCategoryList: [],
+            blockedCategoryNames: '',
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      await channelQueuedStreams(channels);
+
+      expect(chromeMock.tabs.create).toHaveBeenCalledTimes(1);
+      expect(chromeMock.tabs.create).toHaveBeenCalledWith({
+        url: 'https://www.twitch.tv/valid_channel',
+        windowId: null,
+      });
+      expect(channels.slice(0, 4).every(channel => channel.hasBeenOpened !== true)).toBe(true);
+      expect(channels[4].hasBeenOpened).toBe(true);
+    });
+
+    it('should not count invalid queued channels toward the max tab limit', async () => {
+      const channels = [
+        { name: 123, onLive: true, onLiveOpen: true, isPriority: true },
+        { name: 'valid_channel', onLive: true, onLiveOpen: true, isPriority: true },
+      ];
+
+      let existingTabs = [
+        { url: 'https://www.twitch.tv/existing1', id: 101 },
+        { url: 'https://www.twitch.tv/existing2', id: 102 },
+        { url: 'https://www.twitch.tv/existing3', id: 103 },
+        { url: 'https://www.twitch.tv/existing4', id: 104 },
+      ];
+      chromeMock.tabs.query.mockImplementation(() => Promise.resolve([...existingTabs]));
+      chromeMock.tabs.create.mockImplementation(({ url }) => {
+        const newTab = { url, id: existingTabs.length + 200 };
+        existingTabs.push(newTab);
+        return Promise.resolve(newTab);
+      });
+
+      chromeMock.storage.local.get.mockImplementation((keys) => {
+        if (Array.isArray(keys) && keys.includes('isOpenNewWindow')) {
+          return Promise.resolve({ isOpenNewWindow: false, isEnabledMaxTabs: true, maxTabCount: 5 });
+        }
+        if (Array.isArray(keys) && keys.includes('allowedOnlyCategoryList')) {
+          return Promise.resolve({
+            allowedOnlyCategoryList: [],
+            blockedCategoryList: [],
+            blockedCategoryNames: '',
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      await channelQueuedStreams(channels);
+
+      expect(chromeMock.tabs.create).toHaveBeenCalledTimes(1);
+      expect(chromeMock.tabs.create).toHaveBeenCalledWith({
+        url: 'https://www.twitch.tv/valid_channel',
+        windowId: null,
+      });
+      expect(channels[0].hasBeenOpened).toBeUndefined();
+      expect(channels[1].hasBeenOpened).toBe(true);
+    });
+
     it('should default to 5 when maxTabCount is not set', async () => {
       const channels = [
         { name: 'channel1', onLive: true, onLiveOpen: true },


### PR DESCRIPTION
## Summary
- Fixes #138.
- Validates stored channel names before building default Twitch auto-open URLs.
- Skips invalid queued channels without setting `hasBeenOpened` or consuming max-tab capacity, while preserving explicit custom `channel.url` behavior.

## Validation
- `npm test -- tests/background.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`