### PR TITLE
Fix popup stream checks for invalid channel names

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -26,6 +26,7 @@ const aboutBtn = document.getElementById('aboutBtn');
 const liveFilterSwitch = document.getElementById('liveFilterSwitch');
 
 const clientId = 'lt060jwpltwp3weqdk53dx450aj99p';
+const CHANNEL_NAME_REGEX = /^[a-z0-9_]{3,25}$/i;
 
 // Migrate old nested token format { oauth_token: "token" } (object) to flat string "token"
 function migrateOAuthToken(token) {
@@ -41,6 +42,11 @@ function normalizeStoredChannels(channels) {
 
 function normalizeChannelName(channel) {
   return typeof channel?.name === 'string' ? channel.name.toLowerCase() : '';
+}
+
+function getValidTwitchChannelName(channel) {
+  if (typeof channel?.name !== 'string') return '';
+  return CHANNEL_NAME_REGEX.test(channel.name) ? channel.name : '';
 }
 
 function isSameChannel(channel, otherChannel) {
@@ -1398,8 +1404,6 @@ function removeChannel(channel) {
   });
 }
 
-const CHANNEL_NAME_REGEX = /^[a-z0-9_]{3,25}$/i;
-
 channelInput.addEventListener('input', () => {
   channelInput.classList.remove('is-invalid');
 });
@@ -1644,9 +1648,17 @@ function rewriteNeedsLoginButton(isOk) {
 async function checkStream(channel) {
   if (!channel) return;
 
+  const channelName = getValidTwitchChannelName(channel);
+  if (!channelName) {
+    channel.onLive = false;
+    channel.status = 'error';
+    channel.lastError = 'Invalid channel name';
+    return channel;
+  }
+
   const oauth_token = migrateOAuthToken((await chrome.storage.local.get('oauth_token')).oauth_token);
 
-  const url = `https://api.twitch.tv/helix/streams?user_login=${channel.name}`;
+  const url = `https://api.twitch.tv/helix/streams?user_login=${channelName}`;
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 10000);
   const options = {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -64,6 +64,52 @@ describe('Popup Script', () => {
     return sandbox;
   }
 
+  async function loadPopupStreamExports() {
+    const source = await readFile(new URL('../popup.js', import.meta.url), 'utf8');
+    const clientIdSource = source.slice(
+      source.indexOf('const clientId'),
+      source.indexOf('// Migrate old nested token format')
+    );
+    const migrateSource = source.slice(
+      source.indexOf('function migrateOAuthToken'),
+      source.indexOf('function normalizeStoredChannels')
+    );
+    const helperSource = source.slice(
+      source.indexOf('function normalizeStoredChannels'),
+      source.indexOf('// Category search using Twitch API')
+    );
+    const streamSource = source.slice(
+      source.indexOf('async function checkStream'),
+      source.indexOf('// Miteruyoの管理対象ウィンドウでタブを開く')
+    );
+    const sandbox = {
+      chrome: {
+        storage: {
+          local: {
+            get: vi.fn(() => Promise.resolve({ oauth_token: 'token-1' })),
+          },
+        },
+      },
+      fetch: vi.fn(),
+      AbortController,
+      setTimeout,
+      clearTimeout,
+      console: {
+        log: vi.fn(),
+        error: vi.fn(),
+      },
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(
+      `${clientIdSource}\n${migrateSource}\n${helperSource}\n${streamSource}\nglobalThis.__testExports = { checkStream };`,
+      sandbox,
+      { filename: 'popup.js' }
+    );
+
+    return sandbox;
+  }
+
   async function loadPopupChannelExports(channels) {
     const source = await readFile(new URL('../popup.js', import.meta.url), 'utf8');
     const helperSource = source.slice(
@@ -72,7 +118,7 @@ describe('Popup Script', () => {
     );
     const removeSource = source.slice(
       source.indexOf('function removeChannel'),
-      source.indexOf('const CHANNEL_NAME_REGEX')
+      source.indexOf('channelInput.addEventListener')
     );
     const channelSource = source.slice(
       source.indexOf('async function duplicatedChannel'),
@@ -421,5 +467,43 @@ describe('Popup Script', () => {
     expect(checkTwitchConnection).not.toHaveBeenCalled();
     expect(rewriteNeedsLoginButton).toHaveBeenCalledWith(false);
     expect(console.error).toHaveBeenCalledWith('OAuth state mismatch: possible CSRF attack');
+  });
+
+  it.each([
+    ['non-string name', { name: 123 }],
+    ['missing name', { onLiveOpen: true }],
+    ['empty name', { name: '' }],
+    ['too-short name', { name: 'ab' }],
+    ['invalid characters', { name: 'bad user' }],
+  ])('does not query Twitch streams for %s', async (_name, channel) => {
+    const sandbox = await loadPopupStreamExports();
+    const { __testExports, chrome, fetch } = sandbox;
+
+    const result = await __testExports.checkStream(channel);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(chrome.storage.local.get).not.toHaveBeenCalled();
+    expect(result).toBe(channel);
+    expect(result.onLive).toBe(false);
+    expect(result.status).toBe('error');
+    expect(result.lastError).toBe('Invalid channel name');
+  });
+
+  it('queries Twitch streams for valid stored channel names', async () => {
+    const sandbox = await loadPopupStreamExports();
+    const { __testExports, chrome, fetch } = sandbox;
+    fetch.mockResolvedValue({ ok: false, status: 401 });
+    const channel = { name: 'Valid_User' };
+
+    const result = await __testExports.checkStream(channel);
+
+    expect(chrome.storage.local.get).toHaveBeenCalledWith('oauth_token');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toBe('https://api.twitch.tv/helix/streams?user_login=Valid_User');
+    expect(fetch.mock.calls[0][1].headers).toEqual({
+      'Client-ID': 'lt060jwpltwp3weqdk53dx450aj99p',
+      'Authorization': 'Bearer token-1',
+    });
+    expect(result.status).toBe('error');
   });
 });


### PR DESCRIPTION
## Summary
- validate stored popup channel names before building the Twitch streams URL
- return a stable error state for invalid stored channel rows without reading the token or calling fetch
- add popup checkStream regressions for malformed stored names and valid channel requests

Closes #140

## Tests
- npm test -- tests/popup.test.js
- npm test
- npm run lint
- git diff --check