### PR TITLE
[codex] Fix popup invalid channel settings controls

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -49,6 +49,10 @@ function getValidTwitchChannelName(channel) {
   return CHANNEL_NAME_REGEX.test(channel.name) ? channel.name : '';
 }
 
+function canRenderChannelSettings(channel) {
+  return getValidTwitchChannelName(channel) !== '';
+}
+
 function isSameChannel(channel, otherChannel) {
   const channelName = normalizeChannelName(channel);
   const otherChannelName = normalizeChannelName(otherChannel);
@@ -639,6 +643,8 @@ async function addChannelToList(channel, newAdded = false) {
   if (!newAdded && channel.status !== 'error' && liveFilterSwitch.checked && !channel.onLive) return;
 
   let cleanupFn;
+  const validChannelName = getValidTwitchChannelName(channel);
+  const rendersChannelSettings = canRenderChannelSettings(channel);
 
   const pauseMsg = chrome.i18n.getMessage('pause');
 
@@ -660,16 +666,18 @@ async function addChannelToList(channel, newAdded = false) {
     openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusLive') : pauseMsg;
     openButton.setAttribute('class', 'btn btn-outline-success btn-sm');
     openButton.style.width = '72px';
-    openButton.addEventListener('click', () => {
-      openInManagedWindow(channel.name);
-    });
+    if (rendersChannelSettings) {
+      openButton.addEventListener('click', () => {
+        openInManagedWindow(validChannelName);
+      });
+    }
   } else {
     openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusOffline') : pauseMsg;
     openButton.setAttribute('class', 'btn btn-outline-danger btn-sm');
     openButton.style.width = '72px';
   }
 
-  if (channel.status === 'error') {
+  if (channel.status === 'error' || !rendersChannelSettings) {
     openButton.textContent = chrome.i18n.getMessage('statusNotFound');
     openButton.setAttribute('class', 'btn btn-outline-danger btn-sm');
     openButton.style.width = '72px';
@@ -695,7 +703,7 @@ async function addChannelToList(channel, newAdded = false) {
       openButton.setAttribute('class', 'btn btn-outline-success btn-sm');
       openButton.style.width = '72px';
       openButton.addEventListener('click', () => {
-        openInManagedWindow(channel.name);
+        openInManagedWindow(validChannelName);
       });
     } else {
       openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusOffline') : pauseMsg;
@@ -704,12 +712,12 @@ async function addChannelToList(channel, newAdded = false) {
     }
   });
 
-  if (channel.status !== 'error') {
+  if (channel.status !== 'error' && rendersChannelSettings) {
     statusContainer.appendChild(onLiveOpenSwitch);
   }
 
   // Snooze Button (ライブ中かつエラーでない場合のみ表示)
-  if (channel.onLive && channel.status !== 'error') {
+  if (channel.onLive && channel.status !== 'error' && rendersChannelSettings) {
     const snoozeBtn = document.createElement('button');
     const snoozeIcon = document.createElement('i');
     const updateSnoozeUI = () => {
@@ -740,7 +748,7 @@ async function addChannelToList(channel, newAdded = false) {
   }
 
   // Priority Toggle Button (エラーでない場合のみ表示)
-  if (channel.status !== 'error') {
+  if (channel.status !== 'error' && rendersChannelSettings) {
     const priorityBtn = document.createElement('button');
     const priorityIcon = document.createElement('i');
     const updatePriorityUI = () => {
@@ -791,7 +799,9 @@ async function addChannelToList(channel, newAdded = false) {
       nextRow.hidden = !nextRow.hidden;
     }
   };
-  removetd.appendChild(settingsBtn);
+  if (rendersChannelSettings) {
+    removetd.appendChild(settingsBtn);
+  }
 
   // Remove Button
   const removeButton = document.createElement('i');
@@ -819,6 +829,8 @@ async function addChannelToList(channel, newAdded = false) {
   tr.appendChild(removetd);
 
   channelTable.appendChild(tr);
+
+  if (!rendersChannelSettings) return;
 
   // --- Settings Row ---
   const settingsTr = document.createElement('tr');

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -6,7 +6,7 @@ describe('Popup Script', () => {
   async function loadPopupTestExports() {
     const source = await readFile(new URL('../popup.js', import.meta.url), 'utf8');
     const helperSource = source.slice(
-      source.indexOf('function normalizeStoredChannels'),
+      source.indexOf('const CHANNEL_NAME_REGEX'),
       source.indexOf('// Category search using Twitch API')
     );
     const migrationSource = source.slice(
@@ -22,7 +22,7 @@ describe('Popup Script', () => {
 
     vm.createContext(sandbox);
     vm.runInContext(
-      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory, getCategoriesNotAlreadyIncluded, addCategoryIfMissing, removeMatchingCategories };`,
+      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, getValidTwitchChannelName, canRenderChannelSettings, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory, getCategoriesNotAlreadyIncluded, addCategoryIfMissing, removeMatchingCategories };`,
       sandbox,
       { filename: 'popup.js' }
     );
@@ -194,6 +194,25 @@ describe('Popup Script', () => {
       { name: '' },
       { name: '' }
     )).toBe(false);
+  });
+
+  it('only renders settings controls for valid stored channel names', async () => {
+    const { __testExports } = await loadPopupTestExports();
+
+    expect(__testExports.canRenderChannelSettings({ name: 'Valid_User' })).toBe(true);
+    expect(__testExports.getValidTwitchChannelName({ name: 'Valid_User' })).toBe('Valid_User');
+
+    for (const channel of [
+      { name: 123 },
+      { name: {} },
+      {},
+      { name: '' },
+      { name: 'ab' },
+      { name: 'invalid user' },
+    ]) {
+      expect(__testExports.canRenderChannelSettings(channel)).toBe(false);
+      expect(__testExports.getValidTwitchChannelName(channel)).toBe('');
+    }
   });
 
   it('detects manually added channels with different casing as duplicates', async () => {


### PR DESCRIPTION
## Summary

- Prevent malformed stored channel rows from rendering popup settings controls keyed by raw `channel.name`.
- Keep invalid rows visible with the delete affordance so corrupted storage can be cleaned up.
- Reuse the existing Twitch channel-name validation for popup settings eligibility.

Closes #142

## Validation

- `npm test -- tests/popup.test.js`
- `npm test`
- `npm run lint`
- `git diff --check`
