### PR TITLE
[codex] Fix invalid channel row deletion

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -59,6 +59,12 @@ function isSameChannel(channel, otherChannel) {
   return channelName !== '' && channelName === otherChannelName;
 }
 
+function shouldRemoveStoredChannel(storedChannel, targetChannel, storedIndex, targetIndex) {
+  if (isSameChannel(storedChannel, targetChannel)) return true;
+  if (isSameChannel(targetChannel, targetChannel)) return false;
+  return storedIndex === targetIndex && storedChannel !== null;
+}
+
 function normalizeCategoryList(categories) {
   if (!Array.isArray(categories)) return [];
 
@@ -620,12 +626,12 @@ chrome.storage.local.get(
 
 async function updateList(dchannels) {
   const checkStreams = [];
-  for (const _channel of normalizeStoredChannels(dchannels)) {
+  for (const [_index, _channel] of normalizeStoredChannels(dchannels).entries()) {
     checkStreams.push(
       checkStream(_channel)
         .then((channel) => {
           if (channel) {
-            addChannelToList(channel);
+            addChannelToList(channel, false, _index);
             return channel;
           }
         })
@@ -639,7 +645,7 @@ async function updateList(dchannels) {
   }
 }
 
-async function addChannelToList(channel, newAdded = false) {
+async function addChannelToList(channel, newAdded = false, storageIndex = -1) {
   if (!newAdded && channel.status !== 'error' && liveFilterSwitch.checked && !channel.onLive) return;
 
   let cleanupFn;
@@ -816,7 +822,7 @@ async function addChannelToList(channel, newAdded = false) {
         nextRow.remove();
       }
       tr.remove();
-      removeChannel(channel);
+      removeChannel(channel, storageIndex);
       // Cleanup listeners
       if (cleanupFn) {
         cleanupFn();
@@ -1409,9 +1415,10 @@ async function addChannelToList(channel, newAdded = false) {
   channelTable.appendChild(settingsTr);
 }
 
-function removeChannel(channel) {
+function removeChannel(channel, storageIndex = -1) {
   chrome.storage.local.get('channels', (data) => {
-    const newChannels = normalizeStoredChannels(data.channels).filter((c) => !isSameChannel(c, channel));
+    const newChannels = normalizeStoredChannels(data.channels)
+      .filter((c, index) => !shouldRemoveStoredChannel(c, channel, index, storageIndex));
     chrome.storage.local.set({ channels: newChannels });
   });
 }

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -246,6 +246,53 @@ describe('Popup Script', () => {
     });
   });
 
+  it('removes only the clicked malformed stored channel by storage index', async () => {
+    const malformedNumber = { name: 123, marker: 'clicked' };
+    const malformedObject = { name: {}, marker: 'kept-object' };
+    const emptyName = { name: '', marker: 'kept-empty' };
+    const sameMalformedNumber = { name: 123, marker: 'kept-number' };
+    const sandbox = await loadPopupChannelExports([
+      malformedNumber,
+      malformedObject,
+      emptyName,
+      sameMalformedNumber,
+      { name: 'validuser' },
+    ]);
+
+    sandbox.__testExports.removeChannel(malformedNumber, 0);
+
+    expect(sandbox.chrome.storage.local.set).toHaveBeenCalledWith({
+      channels: [
+        malformedObject,
+        emptyName,
+        sameMalformedNumber,
+        { name: 'validuser' },
+      ],
+    });
+  });
+
+  it('removes an empty-name stored channel without wiping other malformed rows', async () => {
+    const malformedNumber = { name: 123 };
+    const emptyName = { name: '' };
+    const nameless = {};
+    const sandbox = await loadPopupChannelExports([
+      malformedNumber,
+      emptyName,
+      nameless,
+      { name: 'validuser' },
+    ]);
+
+    sandbox.__testExports.removeChannel(emptyName, 1);
+
+    expect(sandbox.chrome.storage.local.set).toHaveBeenCalledWith({
+      channels: [
+        malformedNumber,
+        nameless,
+        { name: 'validuser' },
+      ],
+    });
+  });
+
   it('normalizes popup category lists before channel row rendering uses them', async () => {
     const { __testExports } = await loadPopupTestExports();
     const categories = [{ id: '1', name: 'Just Chatting' }];


### PR DESCRIPTION
## Summary
- pass each rendered channel row's original storage index into the delete path
- keep valid channel deletion case-insensitive while removing invalid rows only by their clicked storage index
- add popup regressions for malformed and empty channel-name deletion

Fixes #144

## Validation
- npm test -- tests/popup.test.js
- npm test
- npm run lint
- git diff --check