### PR TITLE
Refactor auto-open control: unified toggle button for Normal/Snooze/Pause states

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A Chrome extension that monitors Twitch channels and automatically opens streams
 - **Desktop Notifications**: Get notified when monitored channels go live
 - **Per-channel Volume Control**: Set custom volume for each channel
 - **Category Filtering**: Only auto-open streams from specific categories
-- **Snooze**: Temporarily suppress auto-open for a channel until the next stream
-- **Priority Channels**: Mark channels as priority to ensure they get tab slots first when max tabs is enabled
+- **Auto-Open Toggle (Snooze / Pause)**: A single per-channel button cycles through Normal → Snoozed (suppress auto-open for the current stream only) → Paused (suppress auto-open until manually reset) → Normal
+- **Priority Channels**: Mark a channel as priority (in its settings panel) to ensure it gets tab slots first when max tabs is enabled
 - **Dynamic Tab Rotation**: Automatically adjust rotation interval based on tab count (e.g., 10min / 5 tabs = 2min per tab)
 
 ## Improvements (v1.0.11+)

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -230,21 +230,29 @@
 		"message": "Open each stream only once",
 		"description": "Option to prevent auto-reopening a stream tab after it has been opened once during a live session"
 	},
-	"snooze": {
-		"message": "Snooze until next stream",
-		"description": "Button label to suppress auto-open until next stream"
-	},
 	"snoozed": {
 		"message": "Snoozed",
 		"description": "Status display when channel is snoozed"
 	},
-	"priorityOn": {
-		"message": "Priority channel",
-		"description": "Tooltip when priority is ON"
+	"autoOpenStateNormal": {
+		"message": "Auto-open enabled (click to snooze)",
+		"description": "Tooltip for the auto-open toggle button: normal state"
 	},
-	"priorityOff": {
-		"message": "Set as priority channel",
-		"description": "Tooltip when priority is OFF"
+	"autoOpenStateSnoozed": {
+		"message": "Snoozed: auto-open suppressed for this stream only (click to pause)",
+		"description": "Tooltip for the auto-open toggle button: snoozed state"
+	},
+	"autoOpenStatePaused": {
+		"message": "Paused: auto-open disabled (click to reset)",
+		"description": "Tooltip for the auto-open toggle button: paused state"
+	},
+	"priorityLabel": {
+		"message": "Priority channel",
+		"description": "Label for the priority channel setting"
+	},
+	"priorityHelp": {
+		"message": "When the tab limit is reached, priority channels are opened first, closing other channels' tabs automatically if needed.",
+		"description": "Explanation for the priority channel setting"
 	},
 	"dynamicRotation": {
 		"message": "Divide by tab count",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -230,21 +230,29 @@
 		"message": "一度開いたら再度開かない",
 		"description": "ライブ配信セッション中に一度タブを開いたら、再度自動で開かないオプション"
 	},
-	"snooze": {
-		"message": "スヌーズ",
-		"description": "次の配信まで自動オープンを抑制するボタンのラベル"
-	},
 	"snoozed": {
 		"message": "スヌーズ中",
 		"description": "スヌーズ中のステータス表示"
 	},
-	"priorityOn": {
-		"message": "優先チャンネル",
-		"description": "優先設定ON時のツールチップ"
+	"autoOpenStateNormal": {
+		"message": "自動オープン中（クリックでスヌーズ）",
+		"description": "自動オープン切り替えボタンのツールチップ：通常状態"
 	},
-	"priorityOff": {
-		"message": "優先チャンネルに設定",
-		"description": "優先設定OFF時のツールチップ"
+	"autoOpenStateSnoozed": {
+		"message": "スヌーズ中：今回の配信のみ自動オープンを止めます（クリックで停止に切り替え）",
+		"description": "自動オープン切り替えボタンのツールチップ：スヌーズ状態"
+	},
+	"autoOpenStatePaused": {
+		"message": "停止中：自動オープンしません（クリックで通常状態に戻す）",
+		"description": "自動オープン切り替えボタンのツールチップ：停止状態"
+	},
+	"priorityLabel": {
+		"message": "優先チャンネル",
+		"description": "優先チャンネル設定のラベル"
+	},
+	"priorityHelp": {
+		"message": "開くタブ数の上限に達した場合、優先チャンネルを優先的に開き、必要に応じて他のチャンネルのタブを自動的に閉じます。",
+		"description": "優先チャンネル設定の説明"
 	},
 	"dynamicRotation": {
 		"message": "タブ数で分割",

--- a/popup.js
+++ b/popup.js
@@ -53,6 +53,17 @@ function canRenderChannelSettings(channel) {
   return getValidTwitchChannelName(channel) !== '';
 }
 
+// 自動オープンの状態を循環させる: 通常 → スヌーズ → 停止 → 通常
+function getNextAutoOpenState(channel) {
+  if (channel.onLiveOpen && channel.snoozed) {
+    return { onLiveOpen: false, snoozed: false }; // スヌーズ → 停止
+  }
+  if (channel.onLiveOpen) {
+    return { onLiveOpen: true, snoozed: true }; // 通常 → スヌーズ
+  }
+  return { onLiveOpen: true, snoozed: false }; // 停止 → 通常
+}
+
 function isSameChannel(channel, otherChannel) {
   const channelName = normalizeChannelName(channel);
   const otherChannelName = normalizeChannelName(otherChannel);
@@ -668,112 +679,68 @@ async function addChannelToList(channel, newAdded = false, storageIndex = -1) {
   const openButton = document.createElement('button');
   statusContainer.appendChild(openButton);
 
-  if (channel.onLive) {
-    openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusLive') : pauseMsg;
-    openButton.setAttribute('class', 'btn btn-outline-success btn-sm');
-    openButton.style.width = '72px';
-    if (rendersChannelSettings) {
-      openButton.addEventListener('click', () => {
-        openInManagedWindow(validChannelName);
-      });
-    }
-  } else {
-    openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusOffline') : pauseMsg;
-    openButton.setAttribute('class', 'btn btn-outline-danger btn-sm');
-    openButton.style.width = '72px';
-  }
-
-  if (channel.status === 'error' || !rendersChannelSettings) {
-    openButton.textContent = chrome.i18n.getMessage('statusNotFound');
-    openButton.setAttribute('class', 'btn btn-outline-danger btn-sm');
-    openButton.style.width = '72px';
-  }
-
-  // On/Off Switch
-  const onLiveOpenSwitch = document.createElement('button');
-  const pauseIcon = document.createElement('i');
-  onLiveOpenSwitch.setAttribute('class', channel.onLiveOpen ? 'btn btn-outline-primary btn-sm' : 'btn btn-outline-danger btn-sm');
-  pauseIcon.setAttribute('class', channel.onLiveOpen ? 'bi bi-pause' : 'bi bi-play');
-  onLiveOpenSwitch.appendChild(pauseIcon);
-
-  onLiveOpenSwitch.addEventListener('click', () => {
-    channel.onLiveOpen = !channel.onLiveOpen;
-    pauseIcon.setAttribute('class', channel.onLiveOpen ? 'bi bi-pause' : 'bi bi-play');
-    onLiveOpenSwitch.setAttribute('class', channel.onLiveOpen ? 'btn btn-outline-primary btn-sm' : 'btn btn-outline-danger btn-sm');
-    saveChannelToList(channel);
-
-    if (channel.snoozed) return; // スヌーズ中はopenButtonを変更しない
-
-    if (channel.onLive) {
-      openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusLive') : pauseMsg;
-      openButton.setAttribute('class', 'btn btn-outline-success btn-sm');
-      openButton.style.width = '72px';
-      openButton.addEventListener('click', () => {
-        openInManagedWindow(validChannelName);
-      });
-    } else {
-      openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusOffline') : pauseMsg;
-      openButton.setAttribute('class', 'btn btn-outline-danger btn-sm');
-      openButton.style.width = '72px';
+  // ライブ中タブを開く（通常状態でライブ中のときのみ有効）
+  openButton.addEventListener('click', () => {
+    if (channel.onLive && rendersChannelSettings) {
+      openInManagedWindow(validChannelName);
     }
   });
 
+  const updateOpenButtonDisplay = () => {
+    openButton.style.width = '72px';
+
+    if (channel.status === 'error' || !rendersChannelSettings) {
+      openButton.textContent = chrome.i18n.getMessage('statusNotFound');
+      openButton.setAttribute('class', 'btn btn-outline-danger btn-sm');
+    } else if (channel.snoozed && channel.onLive) {
+      openButton.textContent = chrome.i18n.getMessage('snoozed');
+      openButton.setAttribute('class', 'btn btn-outline-warning btn-sm');
+    } else if (!channel.onLiveOpen) {
+      openButton.textContent = pauseMsg;
+      openButton.setAttribute('class', channel.onLive ? 'btn btn-outline-success btn-sm' : 'btn btn-outline-danger btn-sm');
+    } else if (channel.onLive) {
+      openButton.textContent = chrome.i18n.getMessage('statusLive');
+      openButton.setAttribute('class', 'btn btn-outline-success btn-sm');
+    } else {
+      openButton.textContent = chrome.i18n.getMessage('statusOffline');
+      openButton.setAttribute('class', 'btn btn-outline-danger btn-sm');
+    }
+  };
+  updateOpenButtonDisplay();
+
+  // Auto-Open Toggle Button: 通常 → スヌーズ → 停止 → 通常 の3状態を1つのボタンで循環
+  const autoOpenToggleBtn = document.createElement('button');
+  const autoOpenToggleIcon = document.createElement('i');
+  autoOpenToggleBtn.appendChild(autoOpenToggleIcon);
+
+  const updateAutoOpenToggleUI = () => {
+    if (channel.snoozed) {
+      autoOpenToggleBtn.setAttribute('class', 'btn btn-warning btn-sm');
+      autoOpenToggleIcon.setAttribute('class', 'bi bi-moon-fill');
+      autoOpenToggleBtn.title = chrome.i18n.getMessage('autoOpenStateSnoozed');
+    } else if (!channel.onLiveOpen) {
+      autoOpenToggleBtn.setAttribute('class', 'btn btn-outline-danger btn-sm');
+      autoOpenToggleIcon.setAttribute('class', 'bi bi-pause-fill');
+      autoOpenToggleBtn.title = chrome.i18n.getMessage('autoOpenStatePaused');
+    } else {
+      autoOpenToggleBtn.setAttribute('class', 'btn btn-outline-secondary btn-sm');
+      autoOpenToggleIcon.setAttribute('class', 'bi bi-play-fill');
+      autoOpenToggleBtn.title = chrome.i18n.getMessage('autoOpenStateNormal');
+    }
+  };
+  updateAutoOpenToggleUI();
+
+  autoOpenToggleBtn.addEventListener('click', () => {
+    const nextState = getNextAutoOpenState(channel);
+    channel.onLiveOpen = nextState.onLiveOpen;
+    channel.snoozed = nextState.snoozed;
+    updateAutoOpenToggleUI();
+    updateOpenButtonDisplay();
+    saveChannelToList(channel);
+  });
+
   if (channel.status !== 'error' && rendersChannelSettings) {
-    statusContainer.appendChild(onLiveOpenSwitch);
-  }
-
-  // Snooze Button (ライブ中かつエラーでない場合のみ表示)
-  if (channel.onLive && channel.status !== 'error' && rendersChannelSettings) {
-    const snoozeBtn = document.createElement('button');
-    const snoozeIcon = document.createElement('i');
-    const updateSnoozeUI = () => {
-      snoozeBtn.setAttribute('class', channel.snoozed ? 'btn btn-warning btn-sm' : 'btn btn-outline-secondary btn-sm');
-      snoozeIcon.setAttribute('class', channel.snoozed ? 'bi bi-moon-fill' : 'bi bi-moon');
-      snoozeBtn.title = channel.snoozed ? chrome.i18n.getMessage('snoozed') : chrome.i18n.getMessage('snooze');
-      if (channel.snoozed) {
-        openButton.textContent = chrome.i18n.getMessage('snoozed');
-        openButton.setAttribute('class', 'btn btn-outline-warning btn-sm');
-        openButton.style.width = '72px';
-      }
-    };
-    snoozeBtn.appendChild(snoozeIcon);
-    updateSnoozeUI();
-
-    snoozeBtn.addEventListener('click', () => {
-      channel.snoozed = !channel.snoozed;
-      updateSnoozeUI();
-      if (!channel.snoozed && channel.onLive) {
-        openButton.textContent = channel.onLiveOpen ? chrome.i18n.getMessage('statusLive') : pauseMsg;
-        openButton.setAttribute('class', 'btn btn-outline-success btn-sm');
-        openButton.style.width = '72px';
-      }
-      saveChannelToList(channel);
-    });
-
-    statusContainer.appendChild(snoozeBtn);
-  }
-
-  // Priority Toggle Button (エラーでない場合のみ表示)
-  if (channel.status !== 'error' && rendersChannelSettings) {
-    const priorityBtn = document.createElement('button');
-    const priorityIcon = document.createElement('i');
-    const updatePriorityUI = () => {
-      priorityBtn.setAttribute('class', channel.isPriority ? 'btn btn-warning btn-sm' : 'btn btn-outline-secondary btn-sm');
-      priorityIcon.setAttribute('class', channel.isPriority ? 'bi bi-star-fill' : 'bi bi-star');
-      const priorityTooltip = channel.isPriority ? chrome.i18n.getMessage('priorityOn') : chrome.i18n.getMessage('priorityOff');
-      priorityBtn.title = priorityTooltip;
-      priorityBtn.setAttribute('aria-label', priorityTooltip);
-    };
-    priorityBtn.appendChild(priorityIcon);
-    updatePriorityUI();
-
-    priorityBtn.addEventListener('click', () => {
-      channel.isPriority = !channel.isPriority;
-      updatePriorityUI();
-      saveChannelToList(channel);
-    });
-
-    statusContainer.appendChild(priorityBtn);
+    statusContainer.appendChild(autoOpenToggleBtn);
   }
 
   // 3. Channel Name
@@ -784,6 +751,17 @@ async function addChannelToList(channel, newAdded = false, storageIndex = -1) {
   cntd.style.whiteSpace = 'nowrap';
   cntd.style.overflow = 'hidden';
   cntd.style.textOverflow = 'ellipsis';
+
+  // 優先チャンネルの表示用インジケーター（設定パネル内のトグルと連動、読み取り専用）
+  const priorityIndicator = document.createElement('i');
+  priorityIndicator.className = 'bi bi-star-fill text-warning me-1';
+  priorityIndicator.title = chrome.i18n.getMessage('priorityLabel');
+  priorityIndicator.hidden = !channel.isPriority;
+  cntd.appendChild(priorityIndicator);
+
+  const updatePriorityIndicator = () => {
+    priorityIndicator.hidden = !channel.isPriority;
+  };
 
   const channelNameTag = document.createElement('span');
   channelNameTag.textContent = channel.name;
@@ -854,6 +832,46 @@ async function addChannelToList(channel, newAdded = false, storageIndex = -1) {
       el.style.opacity = isEnabled ? '1' : '0.5';
     });
   };
+
+  // --- Priority Channel Setting ---
+  const priorityContainer = document.createElement('div');
+  priorityContainer.className = 'd-flex align-items-center mb-2';
+
+  const priorityCheck = document.createElement('input');
+  priorityCheck.type = 'checkbox';
+  priorityCheck.className = 'form-check-input me-2 flex-shrink-0';
+  priorityCheck.style.width = '1.2em';
+  priorityCheck.style.height = '1.2em';
+  priorityCheck.id = `priority-check-${channel.name}`;
+  priorityCheck.checked = !!channel.isPriority;
+
+  const priorityCheckLabel = document.createElement('label');
+  priorityCheckLabel.className = 'form-check-label small me-2 flex-shrink-0';
+  priorityCheckLabel.htmlFor = priorityCheck.id;
+  priorityCheckLabel.textContent = chrome.i18n.getMessage('priorityLabel');
+
+  const priorityHelpIcon = document.createElement('i');
+  priorityHelpIcon.className = 'bi bi-question-circle-fill text-muted';
+  priorityHelpIcon.style.cursor = 'help';
+  priorityHelpIcon.setAttribute('data-bs-toggle', 'tooltip');
+  priorityHelpIcon.setAttribute('data-bs-title', chrome.i18n.getMessage('priorityHelp'));
+  new bootstrap.Tooltip(priorityHelpIcon, { trigger: 'hover click' });
+
+  priorityContainer.appendChild(priorityCheck);
+  priorityContainer.appendChild(priorityCheckLabel);
+  priorityContainer.appendChild(priorityHelpIcon);
+
+  priorityCheck.addEventListener('change', () => {
+    channel.isPriority = priorityCheck.checked;
+    updatePriorityIndicator();
+    saveChannelToList(channel);
+  });
+
+  settingsTd.appendChild(priorityContainer);
+
+  const prioritySeparator = document.createElement('hr');
+  prioritySeparator.className = 'my-2';
+  settingsTd.appendChild(prioritySeparator);
 
   // Custom Volume Control
   const volContainer = document.createElement('div');

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -22,7 +22,7 @@ describe('Popup Script', () => {
 
     vm.createContext(sandbox);
     vm.runInContext(
-      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, getValidTwitchChannelName, canRenderChannelSettings, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory, getCategoriesNotAlreadyIncluded, addCategoryIfMissing, removeMatchingCategories };`,
+      `${helperSource}\n${migrationSource}\nglobalThis.__testExports = { normalizeStoredChannels, normalizeChannelName, getValidTwitchChannelName, canRenderChannelSettings, getNextAutoOpenState, isSameChannel, normalizeCategoryList, migrateBlockedCategories, migrateAllowedOnlyCategories, parseCategoryOptionValue, isSameCategory, includesCategory, getCategoriesNotAlreadyIncluded, addCategoryIfMissing, removeMatchingCategories };`,
       sandbox,
       { filename: 'popup.js' }
     );
@@ -177,6 +177,26 @@ describe('Popup Script', () => {
     expect(__testExports.normalizeStoredChannels(null)).toEqual([]);
     expect(__testExports.normalizeStoredChannels('broken')).toEqual([]);
     expect(__testExports.normalizeStoredChannels({ 0: { name: 'broken' } })).toEqual([]);
+  });
+
+  it('cycles the auto-open toggle through normal -> snoozed -> paused -> normal', async () => {
+    const { __testExports } = await loadPopupTestExports();
+
+    const normal = { onLiveOpen: true, snoozed: false };
+    expect(__testExports.getNextAutoOpenState(normal)).toEqual({ onLiveOpen: true, snoozed: true });
+
+    const snoozed = { onLiveOpen: true, snoozed: true };
+    expect(__testExports.getNextAutoOpenState(snoozed)).toEqual({ onLiveOpen: false, snoozed: false });
+
+    const paused = { onLiveOpen: false, snoozed: false };
+    expect(__testExports.getNextAutoOpenState(paused)).toEqual({ onLiveOpen: true, snoozed: false });
+  });
+
+  it('recovers to normal from an invalid onLiveOpen/snoozed combination', async () => {
+    const { __testExports } = await loadPopupTestExports();
+
+    expect(__testExports.getNextAutoOpenState({ onLiveOpen: false, snoozed: true }))
+      .toEqual({ onLiveOpen: true, snoozed: false });
   });
 
   it('matches channel names case-insensitively for popup duplicate checks', async () => {


### PR DESCRIPTION
## Summary
Consolidates the separate "On/Off" and "Snooze" buttons into a single unified auto-open toggle button that cycles through three states: Normal → Snoozed → Paused → Normal. Moves priority channel control from a quick-toggle button to a dedicated checkbox in the settings panel.

## Key Changes

### UI/UX Improvements
- **Unified Auto-Open Toggle**: Replaced two separate buttons (pause/play + snooze) with one button that cycles through all three states with clear visual indicators and tooltips
  - Normal state: play icon, secondary button
  - Snoozed state: moon icon, warning button (suppresses auto-open for current stream only)
  - Paused state: pause icon, danger button (disables auto-open entirely)
- **Priority Channel Refactor**: Moved from quick-toggle button to checkbox in settings panel with help tooltip explaining the feature
- **Priority Indicator**: Added visual star icon next to channel name when marked as priority

### Code Quality
- **New `getNextAutoOpenState()` function**: Encapsulates state transition logic with clear comments, making the cycling behavior explicit and testable
- **Consolidated button update logic**: Extracted `updateOpenButtonDisplay()` and `updateAutoOpenToggleUI()` functions to reduce duplication and improve maintainability
- **Improved state management**: Single source of truth for button display state, reducing bugs from inconsistent UI updates

### Localization Updates
- Updated message keys to reflect new UI structure:
  - Removed: `snooze`, `priorityOn`, `priorityOff`
  - Added: `autoOpenStateNormal`, `autoOpenStateSnoozed`, `autoOpenStatePaused`, `priorityLabel`, `priorityHelp`
- Updated both English and Japanese locale files with clearer, more descriptive messages

### Testing
- Added unit tests for `getNextAutoOpenState()` covering all state transitions and edge cases
- Exported new function in test harness for verification

## Implementation Details
- State cycling logic handles invalid state combinations (e.g., `onLiveOpen: false, snoozed: true`) by recovering to normal
- Open button display updates reactively when auto-open state changes
- Priority indicator syncs with checkbox state in settings panel
- All state changes persist via `saveChannelToList()`

https://claude.ai/code/session_01Mo3DcihMmJG5KaoHTqKyhh