### PR TITLE
Fix tab rotation to only affect Twitch tabs during manual opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each channel row keeps status and actions compact for the Chrome popup:
 - Gear icon: opens per-channel settings.
 - Trash icon: removes the channel after confirmation.
 
-Tabs opened by Miteruyo are explicitly unmuted when they open. If auto-mute is enabled, inactive managed tabs can still be muted until activation or tab rotation brings them forward.
+Tabs opened by Miteruyo are explicitly unmuted when they open. If auto-mute is enabled, inactive managed Twitch tabs can still be muted until activation or tab rotation brings them forward. Non-Twitch tabs are excluded from rotation and auto-mute.
 
 Twitch's in-player "Click to unmute" state is separate from Chrome's tab mute state, and Miteruyo does not attempt to clear it automatically. Chrome's autoplay policy blocks scripted attempts to unmute or raise the volume on a page that has never received a real user gesture, and forcing it anyway causes Chrome to pause the video outright ("Unmuting failed and the element was paused instead because the user didn't interact with the document before"). A manual click on Twitch's own unmute control is required once per stream; see [known issues](../../issues) for background on why this can't be automated from a content script.
 
@@ -148,7 +148,7 @@ npm run lint:fix
 
 ### Tab Management
 - **Rotation**: Cycles through open stream tabs at set interval
-- **Muting**: Automatically mutes all tabs except the active one
+- **Muting**: Automatically mutes inactive Twitch channel tabs
 - **Auto-close**: Closes tabs when their streams go offline
 - **URL Safety**: Treats only `twitch.tv` and `www.twitch.tv` channel URLs as managed Twitch tabs
 

--- a/background-functions.js
+++ b/background-functions.js
@@ -196,21 +196,6 @@ export async function checkTabRotate() {
   if (tabsToRemove.length > 0) {
     chrome.tabs.remove(tabsToRemove);
   }
-
-  // 動的ローテーション: タブ数に応じてアラーム間隔を再計算
-  if (twitchTabs.length > 1) {
-    const { isDynamicRotation, tabRotationInterval } = await chrome.storage.local.get(['isDynamicRotation', 'tabRotationInterval']);
-    if (isDynamicRotation) {
-      const baseInterval = parseInt(tabRotationInterval, 10) || DEFAULT_ROTATION_INTERVAL_MINUTES;
-      const newInterval = Math.max(MIN_ROTATION_INTERVAL_MINUTES, Math.round(baseInterval / twitchTabs.length));
-      const currentAlarm = await chrome.alarms.get('tabRotationAlarm');
-      if (currentAlarm && currentAlarm.periodInMinutes !== newInterval) {
-        await chrome.alarms.clear('tabRotationAlarm');
-        chrome.alarms.create('tabRotationAlarm', { periodInMinutes: newInterval });
-        console.log('Dynamic rotation: adjusted interval to', newInterval, 'min for', twitchTabs.length, 'tabs');
-      }
-    }
-  }
 }
 
 // Migrate old nested token format { oauth_token: "token" } (object) to flat string "token"

--- a/background-functions.js
+++ b/background-functions.js
@@ -165,43 +165,49 @@ export async function checkTabRotate() {
 
   // If the window exists, switch tabs
   const tabs = await chrome.tabs.query({ windowId: targetWindowId });
-  if (tabs.length > 1) {
-    let currentTabIndex = tabs.findIndex((tab) => tab.active);
-    let nextTabIndex = (currentTabIndex + 1) % tabs.length;
 
-    chrome.tabs.update(tabs[currentTabIndex].id, { muted: enableTabMute });
-    chrome.tabs.update(tabs[nextTabIndex].id, { active: true, muted: false });
+  // Filter tabs to only Twitch channel pages for tab rotation
+  const twitchTabs = tabs.filter(tab => isTwitchChannelPage(tab.url));
 
-    // Close duplicate tabs. Twitch channel pages use channel identity;
-    // other URLs keep the existing URL-without-query behavior.
-    const seenUrls = new Set();
-    const tabsToRemove = [];
-    for (const tab of tabs) {
-      if (!tab.url || !tab.url.startsWith('http')) continue;
-      const channelName = parseTwitchChannelUrl(tab.url);
-      const dedupKey = channelName || tab.url.split('?')[0];
-      if (seenUrls.has(dedupKey)) {
-        tabsToRemove.push(tab.id);
-      } else {
-        seenUrls.add(dedupKey);
-      }
+  // If no Twitch tabs or only one Twitch tab, nothing to rotate
+  if (twitchTabs.length <= 1) return;
+
+  // Use filtered tabs for rotation logic
+  let currentTabIndex = twitchTabs.findIndex((tab) => tab.active);
+  let nextTabIndex = (currentTabIndex + 1) % twitchTabs.length;
+
+  chrome.tabs.update(twitchTabs[currentTabIndex].id, { muted: enableTabMute });
+  chrome.tabs.update(twitchTabs[nextTabIndex].id, { active: true, muted: false });
+
+  // Close duplicate tabs. Twitch channel pages use channel identity;
+  // other URLs keep the existing URL-without-query behavior.
+  const seenUrls = new Set();
+  const tabsToRemove = [];
+  for (const tab of twitchTabs) {
+    if (!tab.url || !tab.url.startsWith('http')) continue;
+    const channelName = parseTwitchChannelUrl(tab.url);
+    const dedupKey = channelName || tab.url.split('?')[0];
+    if (seenUrls.has(dedupKey)) {
+      tabsToRemove.push(tab.id);
+    } else {
+      seenUrls.add(dedupKey);
     }
-    if (tabsToRemove.length > 0) {
-      chrome.tabs.remove(tabsToRemove);
-    }
+  }
+  if (tabsToRemove.length > 0) {
+    chrome.tabs.remove(tabsToRemove);
   }
 
   // 動的ローテーション: タブ数に応じてアラーム間隔を再計算
-  if (tabs.length > 1) {
+  if (twitchTabs.length > 1) {
     const { isDynamicRotation, tabRotationInterval } = await chrome.storage.local.get(['isDynamicRotation', 'tabRotationInterval']);
     if (isDynamicRotation) {
       const baseInterval = parseInt(tabRotationInterval, 10) || DEFAULT_ROTATION_INTERVAL_MINUTES;
-      const newInterval = Math.max(MIN_ROTATION_INTERVAL_MINUTES, Math.round(baseInterval / tabs.length));
+      const newInterval = Math.max(MIN_ROTATION_INTERVAL_MINUTES, Math.round(baseInterval / twitchTabs.length));
       const currentAlarm = await chrome.alarms.get('tabRotationAlarm');
       if (currentAlarm && currentAlarm.periodInMinutes !== newInterval) {
         await chrome.alarms.clear('tabRotationAlarm');
         chrome.alarms.create('tabRotationAlarm', { periodInMinutes: newInterval });
-        console.log('Dynamic rotation: adjusted interval to', newInterval, 'min for', tabs.length, 'tabs');
+        console.log('Dynamic rotation: adjusted interval to', newInterval, 'min for', twitchTabs.length, 'tabs');
       }
     }
   }

--- a/background-functions.js
+++ b/background-functions.js
@@ -166,35 +166,55 @@ export async function checkTabRotate() {
   // If the window exists, switch tabs
   const tabs = await chrome.tabs.query({ windowId: targetWindowId });
 
-  // Filter tabs to only Twitch channel pages for tab rotation
+  // Only Twitch channel pages are managed by rotation.
   const twitchTabs = tabs.filter(tab => isTwitchChannelPage(tab.url));
 
-  // If no Twitch tabs or only one Twitch tab, nothing to rotate
-  if (twitchTabs.length <= 1) return;
-
-  // Use filtered tabs for rotation logic
-  let currentTabIndex = twitchTabs.findIndex((tab) => tab.active);
-  let nextTabIndex = (currentTabIndex + 1) % twitchTabs.length;
-
-  chrome.tabs.update(twitchTabs[currentTabIndex].id, { muted: enableTabMute });
-  chrome.tabs.update(twitchTabs[nextTabIndex].id, { active: true, muted: false });
-
-  // Close duplicate tabs. Twitch channel pages use channel identity;
-  // other URLs keep the existing URL-without-query behavior.
-  const seenUrls = new Set();
+  // Resolve duplicates before choosing the next tab. Prefer the active tab so
+  // rotation never removes the tab the user is currently viewing.
+  const survivingTabByChannel = new Map();
   const tabsToRemove = [];
   for (const tab of twitchTabs) {
-    if (!tab.url || !tab.url.startsWith('http')) continue;
     const channelName = parseTwitchChannelUrl(tab.url);
-    const dedupKey = channelName || tab.url.split('?')[0];
-    if (seenUrls.has(dedupKey)) {
-      tabsToRemove.push(tab.id);
+    const existingTab = survivingTabByChannel.get(channelName);
+    if (!existingTab) {
+      survivingTabByChannel.set(channelName, tab);
+    } else if (tab.active && !existingTab.active) {
+      tabsToRemove.push(existingTab.id);
+      survivingTabByChannel.set(channelName, tab);
     } else {
-      seenUrls.add(dedupKey);
+      tabsToRemove.push(tab.id);
     }
   }
   if (tabsToRemove.length > 0) {
-    chrome.tabs.remove(tabsToRemove);
+    await chrome.tabs.remove(tabsToRemove);
+  }
+
+  const survivingTabIds = new Set(
+    [...survivingTabByChannel.values()].map(tab => tab.id)
+  );
+  const rotationTabs = twitchTabs.filter(tab => survivingTabIds.has(tab.id));
+
+  // 動的ローテーション: Twitchタブ数に応じてアラーム間隔を再計算
+  const { isDynamicRotation, tabRotationInterval } = await chrome.storage.local.get(['isDynamicRotation', 'tabRotationInterval']);
+  if (isDynamicRotation) {
+    const baseInterval = parseInt(tabRotationInterval, 10) || DEFAULT_ROTATION_INTERVAL_MINUTES;
+    const rotationTabCount = Math.max(1, rotationTabs.length);
+    const newInterval = Math.max(MIN_ROTATION_INTERVAL_MINUTES, Math.round(baseInterval / rotationTabCount));
+    const currentAlarm = await chrome.alarms.get('tabRotationAlarm');
+    if (currentAlarm && currentAlarm.periodInMinutes !== newInterval) {
+      await chrome.alarms.clear('tabRotationAlarm');
+      await chrome.alarms.create('tabRotationAlarm', { periodInMinutes: newInterval });
+      console.log('Dynamic rotation: adjusted interval to', newInterval, 'min for', rotationTabs.length, 'Twitch tabs');
+    }
+  }
+
+  if (rotationTabs.length <= 1) return;
+
+  const currentTabIndex = rotationTabs.findIndex((tab) => tab.active);
+  if (currentTabIndex >= 0) {
+    const nextTabIndex = (currentTabIndex + 1) % rotationTabs.length;
+    await chrome.tabs.update(rotationTabs[currentTabIndex].id, { muted: enableTabMute });
+    await chrome.tabs.update(rotationTabs[nextTabIndex].id, { active: true, muted: false });
   }
 }
 

--- a/background.js
+++ b/background.js
@@ -162,7 +162,7 @@ chrome.tabs.onActivated.addListener(async activeInfo => {
       console.log('activated', activeInfo, enableTabMute, enableAutoClose);
       if (enableTabMute) {
         const tabs = await chrome.tabs.query({ windowId: targetWindowId });
-        await Promise.all(tabs.map(tab =>
+        await Promise.all(tabs.filter(tab => isTwitchChannelPage(tab.url)).map(tab =>
           chrome.tabs.update(tab.id, { muted: tab.id !== activeInfo.tabId })
         ));
       }

--- a/tests/background-script.test.js
+++ b/tests/background-script.test.js
@@ -24,7 +24,7 @@ const backgroundFunctionsMock = vi.hoisted(() => ({
 
 vi.mock('../background-functions.js', () => backgroundFunctionsMock);
 
-describe('background.js context menu channel add', () => {
+describe('background.js event handlers', () => {
   let chromeMock;
   let originalChrome;
 
@@ -32,6 +32,12 @@ describe('background.js context menu channel add', () => {
     vi.resetModules();
     await import('../background.js');
     return chromeMock.contextMenus.onClicked.addListener.mock.calls[0][0];
+  }
+
+  async function loadTabActivatedHandler() {
+    vi.resetModules();
+    await import('../background.js');
+    return chromeMock.tabs.onActivated.addListener.mock.calls[0][0];
   }
 
   beforeEach(() => {
@@ -137,5 +143,45 @@ describe('background.js context menu channel add', () => {
     await handler(42);
 
     expect(backgroundFunctionsMock.onWindowRemoved).toHaveBeenCalledWith(42);
+  });
+
+  it('mutes only Twitch channel tabs when a Twitch tab is activated', async () => {
+    chromeMock.storage.local.get.mockResolvedValue({
+      lastOpenWindowId: 42,
+      isEnabledTabMute: true,
+      isEnabledAutoClose: false,
+    });
+    chromeMock.tabs.query.mockResolvedValue([
+      { id: 10, url: 'https://www.twitch.tv/active_channel' },
+      { id: 11, url: 'https://www.twitch.tv/inactive_channel' },
+      { id: 12, url: 'https://example.com/' },
+    ]);
+    const handler = await loadTabActivatedHandler();
+
+    await handler({ windowId: 42, tabId: 10 });
+
+    expect(chromeMock.tabs.update).toHaveBeenCalledTimes(2);
+    expect(chromeMock.tabs.update).toHaveBeenNthCalledWith(1, 10, { muted: false });
+    expect(chromeMock.tabs.update).toHaveBeenNthCalledWith(2, 11, { muted: true });
+  });
+
+  it('leaves an active non-Twitch tab unchanged while muting Twitch channel tabs', async () => {
+    chromeMock.storage.local.get.mockResolvedValue({
+      lastOpenWindowId: 42,
+      isEnabledTabMute: true,
+      isEnabledAutoClose: false,
+    });
+    chromeMock.tabs.query.mockResolvedValue([
+      { id: 10, url: 'https://www.twitch.tv/channel_one' },
+      { id: 11, url: 'https://www.twitch.tv/channel_two' },
+      { id: 12, url: 'https://example.com/' },
+    ]);
+    const handler = await loadTabActivatedHandler();
+
+    await handler({ windowId: 42, tabId: 12 });
+
+    expect(chromeMock.tabs.update).toHaveBeenCalledTimes(2);
+    expect(chromeMock.tabs.update).toHaveBeenNthCalledWith(1, 10, { muted: true });
+    expect(chromeMock.tabs.update).toHaveBeenNthCalledWith(2, 11, { muted: true });
   });
 });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1981,6 +1981,73 @@ describe('Background Script', () => {
         expect(chromeMock.tabs.update).toHaveBeenCalledWith(2, { active: true, muted: false });
       });
 
+      it('should rotate only Twitch tabs in a mixed window', async () => {
+        const windowId = 123;
+        const tabs = [
+          { id: 1, url: 'https://example.com/docs', active: false },
+          { id: 2, url: 'https://www.twitch.tv/channel1', active: true },
+          { id: 3, url: 'https://www.twitch.tv/channel2', active: false },
+        ];
+
+        chromeMock.storage.local.get.mockImplementation((key) => {
+          if (key === 'isEnabledTabRotation') {
+            return Promise.resolve({ isEnabledTabRotation: true });
+          }
+          if (key === 'lastOpenWindowId') {
+            return Promise.resolve({ lastOpenWindowId: windowId });
+          }
+          if (key === 'isEnabledTabMute') {
+            return Promise.resolve({ isEnabledTabMute: false });
+          }
+          return Promise.resolve({});
+        });
+
+        chromeMock.windows.get.mockResolvedValue({ id: windowId });
+        chromeMock.tabs.query.mockResolvedValue(tabs);
+
+        await checkTabRotate();
+
+        expect(chromeMock.tabs.update.mock.calls).toEqual([
+          [2, { muted: false }],
+          [3, { active: true, muted: false }],
+        ]);
+      });
+
+      it('should leave the active non-Twitch tab unchanged', async () => {
+        const windowId = 123;
+        const tabs = [
+          { id: 1, url: 'https://example.com/docs', active: true },
+          { id: 2, url: 'https://www.twitch.tv/channel1', active: false },
+          { id: 3, url: 'https://www.twitch.tv/channel2', active: false },
+        ];
+
+        chromeMock.storage.local.get.mockImplementation((key) => {
+          if (key === 'isEnabledTabRotation') {
+            return Promise.resolve({ isEnabledTabRotation: true });
+          }
+          if (key === 'lastOpenWindowId') {
+            return Promise.resolve({ lastOpenWindowId: windowId });
+          }
+          if (key === 'isEnabledTabMute') {
+            return Promise.resolve({ isEnabledTabMute: true });
+          }
+          if (Array.isArray(key) && key.includes('isDynamicRotation')) {
+            return Promise.resolve({ isDynamicRotation: true, tabRotationInterval: 10 });
+          }
+          return Promise.resolve({});
+        });
+
+        chromeMock.windows.get.mockResolvedValue({ id: windowId });
+        chromeMock.tabs.query.mockResolvedValue(tabs);
+        chromeMock.alarms.get.mockResolvedValue({ name: 'tabRotationAlarm', periodInMinutes: 10 });
+        chromeMock.alarms.clear.mockResolvedValue(true);
+
+        await expect(checkTabRotate()).resolves.toBeUndefined();
+
+        expect(chromeMock.tabs.update).not.toHaveBeenCalled();
+        expect(chromeMock.alarms.create).toHaveBeenCalledWith('tabRotationAlarm', { periodInMinutes: 5 });
+      });
+
       it('should remove casing-equivalent Twitch channel tabs during rotation', async () => {
         const windowId = 123;
         const tabs = [
@@ -2010,12 +2077,54 @@ describe('Background Script', () => {
         expect(chromeMock.tabs.remove).toHaveBeenCalledWith([3]);
       });
 
-      it('should keep non-Twitch tabs with casing-different paths during rotation', async () => {
+      it('should deduplicate before rotating and use surviving Twitch tabs for the dynamic interval', async () => {
         const windowId = 123;
         const tabs = [
-          { id: 1, url: 'https://example.com/TestUser', active: true },
-          { id: 2, url: 'https://example.com/testuser', active: false },
-          { id: 3, url: 'https://example.com/TestUser?ref=duplicate', active: false },
+          { id: 1, url: 'https://www.twitch.tv/channel1', active: true },
+          { id: 2, url: 'https://www.twitch.tv/CHANNEL1', active: false },
+          { id: 3, url: 'https://www.twitch.tv/channel2', active: false },
+        ];
+
+        chromeMock.storage.local.get.mockImplementation((key) => {
+          if (key === 'isEnabledTabRotation') {
+            return Promise.resolve({ isEnabledTabRotation: true });
+          }
+          if (key === 'lastOpenWindowId') {
+            return Promise.resolve({ lastOpenWindowId: windowId });
+          }
+          if (key === 'isEnabledTabMute') {
+            return Promise.resolve({ isEnabledTabMute: false });
+          }
+          if (Array.isArray(key) && key.includes('isDynamicRotation')) {
+            return Promise.resolve({ isDynamicRotation: true, tabRotationInterval: 10 });
+          }
+          return Promise.resolve({});
+        });
+
+        chromeMock.windows.get.mockResolvedValue({ id: windowId });
+        chromeMock.tabs.query.mockResolvedValue(tabs);
+        chromeMock.alarms.get.mockResolvedValue({ name: 'tabRotationAlarm', periodInMinutes: 10 });
+        chromeMock.alarms.clear.mockResolvedValue(true);
+
+        await checkTabRotate();
+
+        expect(chromeMock.tabs.remove).toHaveBeenCalledWith([2]);
+        expect(chromeMock.tabs.update.mock.calls).toEqual([
+          [1, { muted: false }],
+          [3, { active: true, muted: false }],
+        ]);
+        expect(chromeMock.tabs.remove.mock.invocationCallOrder[0])
+          .toBeLessThan(chromeMock.tabs.update.mock.invocationCallOrder[0]);
+        expect(chromeMock.alarms.create).toHaveBeenCalledWith('tabRotationAlarm', { periodInMinutes: 5 });
+      });
+
+      it('should not remove duplicate non-Twitch tabs during rotation', async () => {
+        const windowId = 123;
+        const tabs = [
+          { id: 1, url: 'https://www.twitch.tv/channel1', active: true },
+          { id: 2, url: 'https://www.twitch.tv/channel2', active: false },
+          { id: 3, url: 'https://example.com/TestUser', active: false },
+          { id: 4, url: 'https://example.com/TestUser?ref=duplicate', active: false },
         ];
 
         chromeMock.storage.local.get.mockImplementation((key) => {
@@ -2036,7 +2145,7 @@ describe('Background Script', () => {
 
         await checkTabRotate();
 
-        expect(chromeMock.tabs.remove).toHaveBeenCalledWith([3]);
+        expect(chromeMock.tabs.remove).not.toHaveBeenCalled();
       });
 
       it('should clear lastOpenWindowId when window does not exist', async () => {
@@ -2099,6 +2208,43 @@ describe('Background Script', () => {
         // 10 min / 5 tabs = 2 min per tab
         expect(chromeMock.alarms.clear).toHaveBeenCalledWith('tabRotationAlarm');
         expect(chromeMock.alarms.create).toHaveBeenCalledWith('tabRotationAlarm', { periodInMinutes: 2 });
+      });
+
+      it('should exclude non-Twitch tabs from the dynamic rotation interval', async () => {
+        const windowId = 123;
+        const tabs = [
+          { id: 1, url: 'https://www.twitch.tv/channel1', active: true },
+          { id: 2, url: 'https://example.com/docs', active: false },
+          { id: 3, url: 'https://www.twitch.tv/channel2', active: false },
+          { id: 4, url: 'https://example.com/mail', active: false },
+          { id: 5, url: 'https://www.twitch.tv/channel3', active: false },
+        ];
+
+        chromeMock.storage.local.get.mockImplementation((key) => {
+          if (key === 'isEnabledTabRotation') {
+            return Promise.resolve({ isEnabledTabRotation: true });
+          }
+          if (key === 'lastOpenWindowId') {
+            return Promise.resolve({ lastOpenWindowId: windowId });
+          }
+          if (key === 'isEnabledTabMute') {
+            return Promise.resolve({ isEnabledTabMute: false });
+          }
+          if (Array.isArray(key) && key.includes('isDynamicRotation')) {
+            return Promise.resolve({ isDynamicRotation: true, tabRotationInterval: 12 });
+          }
+          return Promise.resolve({});
+        });
+
+        chromeMock.windows.get.mockResolvedValue({ id: windowId });
+        chromeMock.tabs.query.mockResolvedValue(tabs);
+        chromeMock.alarms.get.mockResolvedValue({ name: 'tabRotationAlarm', periodInMinutes: 12 });
+        chromeMock.alarms.clear.mockResolvedValue(true);
+
+        await checkTabRotate();
+
+        // 12 min / 3 Twitch tabs = 4 min; unrelated tabs are excluded.
+        expect(chromeMock.alarms.create).toHaveBeenCalledWith('tabRotationAlarm', { periodInMinutes: 4 });
       });
 
       it('should not recalculate alarm when dynamic rotation is disabled', async () => {
@@ -2169,10 +2315,11 @@ describe('Background Script', () => {
         expect(chromeMock.alarms.create).toHaveBeenCalledWith('tabRotationAlarm', { periodInMinutes: 1 });
       });
 
-      it('should not recalculate when only 1 tab exists even if dynamic rotation is enabled', async () => {
+      it('should keep the active duplicate and restore the base interval when one Twitch tab survives', async () => {
         const windowId = 123;
         const tabs = [
-          { id: 1, url: 'https://www.twitch.tv/channel1', active: true },
+          { id: 1, url: 'https://www.twitch.tv/channel1', active: false },
+          { id: 2, url: 'https://www.twitch.tv/CHANNEL1', active: true },
         ];
 
         chromeMock.storage.local.get.mockImplementation((key) => {
@@ -2185,16 +2332,22 @@ describe('Background Script', () => {
           if (key === 'isEnabledTabMute') {
             return Promise.resolve({ isEnabledTabMute: false });
           }
+          if (Array.isArray(key) && key.includes('isDynamicRotation')) {
+            return Promise.resolve({ isDynamicRotation: true, tabRotationInterval: 10 });
+          }
           return Promise.resolve({});
         });
 
         chromeMock.windows.get.mockResolvedValue({ id: windowId });
         chromeMock.tabs.query.mockResolvedValue(tabs);
+        chromeMock.alarms.get.mockResolvedValue({ name: 'tabRotationAlarm', periodInMinutes: 5 });
+        chromeMock.alarms.clear.mockResolvedValue(true);
 
         await checkTabRotate();
 
-        // With only 1 tab, dynamic rotation block is skipped (tabs.length > 1 guard)
-        expect(chromeMock.alarms.create).not.toHaveBeenCalled();
+        expect(chromeMock.tabs.remove).toHaveBeenCalledWith([1]);
+        expect(chromeMock.tabs.update).not.toHaveBeenCalled();
+        expect(chromeMock.alarms.create).toHaveBeenCalledWith('tabRotationAlarm', { periodInMinutes: 10 });
       });
 
       it('should not recreate alarm when interval is already correct', async () => {


### PR DESCRIPTION
# Fix tab rotation to only affect Twitch tabs during manual opens

## Summary

Fixes the issue where manually opened Twitch tabs caused unrelated tabs in the same window to be rotated, activated, muted, or deduplicated. Tab rotation and auto-mute now manage only validated Twitch channel pages.

Fixes #153

## Changes

- Filters rotation, duplicate removal, and `tabs.onActivated` auto-mute to validated Twitch channel tabs
- Safely skips activation changes when the active tab is not a Twitch channel
- Deduplicates Twitch channels before rotating, preserving the active duplicate
- Calculates dynamic rotation intervals from surviving Twitch channels and restores the base interval when zero or one channel remains
- Awaits tab and alarm mutations so failures remain observable to the service worker
- Documents that non-Twitch tabs are excluded from rotation and auto-mute

## Testing

- `npm test -- --silent --reporter=dot`: 207/207 passed
- `npm run test:coverage -- --silent --reporter=dot`: 207/207 passed; `background-functions.js` statement coverage 93.31%
- `npm run lint`: passed
- `git diff --check`: passed
- Independent Codex/Sol review: no remaining findings

---
### AI assistance disclosure

The initial contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.

Review-driven fixes in commit `a570fd7` were produced with Codex under maintainer supervision.